### PR TITLE
Ci/cargo publish on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "**"
+
+jobs:
+  lint:
+    if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
+    uses: ./.github/workflows/lint.yml
+
+  build:
+    if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
+    uses: ./.github/workflows/build.yml
+
+  test:
+    if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
+    uses: ./.github/workflows/test.yml
+
+  perform-publish:
+    if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
+    needs:
+      - lint
+      - build
+      - test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.OPS_TOKEN }}
+
+      - name: Setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.75
+          default: true
+          override: true
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.29.0"
+
+      - name: Cargo install smart-release
+        run: cargo install cargo-smart-release
+
+      - name: Publish crates to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo smart-release --execute --update-crates-index --no-push --no-changelog --no-changelog-github-release \
+          axone-rdf \
+          axone-wasm \
+          axone-objectarium-client \
+          axone-logic-bindings \
+          axone-cognitarium-client \
+          axone-objectarium \
+          axone-cognitarium \
+          axone-law-stone \
+          axone-dataverse

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Publish crates to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo workspaces publish --publish-as-is --allow-branch main
+        run: cargo make publish-crates

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,25 +38,7 @@ jobs:
           default: true
           override: true
 
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: "3.29.0"
-
-      - name: Cargo install smart-release
-        run: cargo install cargo-smart-release
-
       - name: Publish crates to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          cargo smart-release --execute --update-crates-index --no-push --no-changelog --no-changelog-github-release \
-          axone-rdf \
-          axone-wasm \
-          axone-objectarium-client \
-          axone-logic-bindings \
-          axone-cognitarium-client \
-          axone-objectarium \
-          axone-cognitarium \
-          axone-law-stone \
-          axone-dataverse
+        run: cargo workspaces publish --publish-as-is --allow-branch main

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -37,7 +37,10 @@ plugins:
           to: version = "${nextRelease.version}"
   - - "@semantic-release/exec"
     - prepareCmd: |
-        cargo make schema && cargo make docs-generate && cargo make release-wasm
+        cargo make update-workspace-dependency-versions ${nextRelease.version} && \
+        cargo make schema && \
+        cargo make docs-generate && \
+        cargo make release-wasm
   - - "@semantic-release/github"
     - successComment: false
       assets:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 members = ["contracts/*", "packages/*"]
 resolver = "2"
 
+[workspace.package]
+authors = ["AXONE"]
+homepage = "https://axone.xyz/"
+license-file = "LICENSE"
+
 [profile.release]
 codegen-units = 1
 debug = false
@@ -16,15 +21,15 @@ rpath = false
 [workspace.dependencies]
 axone-cognitarium = { path = "contracts/axone-cognitarium", features = [
   "library",
-] }
-axone-cognitarium-client = { path = "packages/axone-cognitarium-client" }
-axone-logic-bindings = { path = "packages/axone-logic-bindings" }
+], version = "5.0.0" }
+axone-cognitarium-client = { path = "packages/axone-cognitarium-client", version = "5.0.0" }
+axone-logic-bindings = { path = "packages/axone-logic-bindings", version = "5.0.0" }
 axone-objectarium = { path = "contracts/axone-objectarium", features = [
   "library",
-] }
-axone-objectarium-client = { path = "packages/axone-objectarium-client" }
-axone-rdf = { path = "packages/axone-rdf" }
-axone-wasm = { path = "packages/axone-wasm" }
+], version = "5.0.0" }
+axone-objectarium-client = { path = "packages/axone-objectarium-client", version = "5.0.0" }
+axone-rdf = { path = "packages/axone-rdf", version = "5.0.0" }
+axone-wasm = { path = "packages/axone-wasm", version = "5.0.0" }
 cosmwasm-schema = "1.5.5"
 cosmwasm-std = { version = "1.5.5", features = ["cosmwasm_1_2"] }
 cosmwasm-storage = "1.5.2"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -620,6 +620,10 @@ for workspace_dependency in ${workspace_dependencies[@]}; do
 done
 '''
 
+[tasks.publish-crates]
+dependencies = ["install-cargo-workspaces"]
+script = "cargo workspaces publish --publish-as-is"
+
 [tasks.install-llvm-tools-preview]
 install_crate = { rustup_component_name = "llvm-tools-preview" }
 
@@ -659,6 +663,9 @@ install_crate = { crate_name = "cargo-hack", min_version = "0.6.14" }
 
 [tasks.install-toml-cli]
 install_crate = { crate_name = "toml-cli", min_version = "0.2.3" }
+
+[tasks.install-cargo-workspaces]
+install_crate = { crate_name = "cargo-workspaces", min_version = "0.3.2" }
 
 [config]
 default_to_workspace = false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -604,13 +604,20 @@ docker run --rm \
 dependencies = ["install-toml-cli"]
 script = '''
 next_version=$1
-toml set Cargo.toml workspace.dependencies.axone-cognitarium.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-toml set Cargo.toml workspace.dependencies.axone-rdf.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-toml set Cargo.toml workspace.dependencies.axone-wasm.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-toml set Cargo.toml workspace.dependencies.axone-cognitarium-client.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-toml set Cargo.toml workspace.dependencies.axone-logic-bindings.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-toml set Cargo.toml workspace.dependencies.axone-objectarium.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-toml set Cargo.toml workspace.dependencies.axone-objectarium-client.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+
+workspace_dependencies=( \
+  axone-cognitarium \
+  axone-rdf \
+  axone-wasm \
+  axone-cognitarium-client \
+  axone-logic-bindings \
+  axone-objectarium \
+  axone-objectarium-client \
+)
+
+for workspace_dependency in ${workspace_dependencies[@]}; do
+  toml set Cargo.toml workspace.dependencies.$workspace_dependency.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+done
 '''
 
 [tasks.install-llvm-tools-preview]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -600,6 +600,19 @@ docker run --rm \
           | jq -r '.'
 '''
 
+[tasks.update-workspace-dependency-versions]
+dependencies = ["install-toml-cli"]
+script = '''
+next_version=$1
+toml set Cargo.toml workspace.dependencies.axone-cognitarium.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+toml set Cargo.toml workspace.dependencies.axone-rdf.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+toml set Cargo.toml workspace.dependencies.axone-wasm.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+toml set Cargo.toml workspace.dependencies.axone-cognitarium-client.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+toml set Cargo.toml workspace.dependencies.axone-logic-bindings.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+toml set Cargo.toml workspace.dependencies.axone-objectarium.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+toml set Cargo.toml workspace.dependencies.axone-objectarium-client.version $next_version > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+'''
+
 [tasks.install-llvm-tools-preview]
 install_crate = { rustup_component_name = "llvm-tools-preview" }
 
@@ -636,6 +649,9 @@ fi
 
 [tasks.install-cargo-hack]
 install_crate = { crate_name = "cargo-hack", min_version = "0.6.14" }
+
+[tasks.install-toml-cli]
+install_crate = { crate_name = "toml-cli", min_version = "0.2.3" }
 
 [config]
 default_to_workspace = false

--- a/contracts/axone-cognitarium/Cargo.toml
+++ b/contracts/axone-cognitarium/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
-authors = ["AXONE"]
+authors.workspace = true
+categories = ["cryptography::cryptocurrencies"]
+description = "A CosmWasm Smart Contract which enables the storage and querying of Semantic data using RDF (Resource Description Framework), which represents information as semantic triples."
+documentation = "https://docs.axone.xyz/contracts/okp4-cognitarium"
 edition = "2021"
+homepage.workspace = true
+license-file.workspace = true
 name = "axone-cognitarium"
+readme = "README.md"
+repository = "https://github.com/axone-protocol/contracts/tree/main/contracts/axone-cognitarium"
 rust-version = "1.75"
 version = "5.0.0"
 

--- a/contracts/axone-dataverse/Cargo.toml
+++ b/contracts/axone-dataverse/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
-authors = ["AXONE"]
+authors.workspace = true
+categories = ["cryptography::cryptocurrencies"]
+description = 'A CosmWasm Smart Contract which enables the orchestration of "Dataverses", a collection of digital resources governed by rules set by what is called a "Zone".'
+documentation = "https://docs.axone.xyz/contracts/okp4-dataverse"
 edition = "2021"
+homepage.workspace = true
+license-file.workspace = true
 name = "axone-dataverse"
+readme = "README.md"
+repository = "https://github.com/axone-protocol/contracts/tree/main/contracts/axone-dataverse"
 rust-version = "1.75"
 version = "5.0.0"
 

--- a/contracts/axone-law-stone/Cargo.toml
+++ b/contracts/axone-law-stone/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
-authors = ["AXONE"]
+authors.workspace = true
+categories = ["cryptography::cryptocurrencies"]
+description = "A CosmWasm Smart Contract which aims to provide GaaS (Governance as a Service) in any Cosmos blockchains."
+documentation = "https://docs.axone.xyz/contracts/okp4-law-stone"
 edition = "2021"
+homepage.workspace = true
+license-file.workspace = true
 name = "axone-law-stone"
+readme = "README.md"
+repository = "https://github.com/axone-protocol/contracts/tree/main/contracts/axone-law-stone"
 rust-version = "1.75"
 version = "5.0.0"
 

--- a/contracts/axone-objectarium/Cargo.toml
+++ b/contracts/axone-objectarium/Cargo.toml
@@ -1,7 +1,18 @@
 [package]
-authors = ["AXONE"]
+authors.workspace = true
+categories = [
+  "cryptography::cryptocurrencies",
+  "data-structures",
+  "database-implementations",
+]
+description = "A CosmWasm Smart Contract which enables the storage of arbitrary unstructured Objects in any Cosmos blockchains."
+documentation = "https://docs.axone.xyz/contracts/okp4-objectarium"
 edition = "2021"
+homepage.workspace = true
+license-file.workspace = true
 name = "axone-objectarium"
+readme = "README.md"
+repository = "https://github.com/axone-protocol/contracts/tree/main/contracts/axone-objectarium"
 rust-version = "1.75"
 version = "5.0.0"
 

--- a/packages/axone-cognitarium-client/Cargo.toml
+++ b/packages/axone-cognitarium-client/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
-authors = ["AXONE"]
+authors.workspace = true
+categories = ["cryptography::cryptocurrencies"]
+description = "Package that holds components to interact with the `axone-cognitarium` contract."
+documentation = "https://docs.axone.xyz/contracts/okp4-cognitarium"
 edition = "2021"
+homepage.workspace = true
+license-file.workspace = true
 name = "axone-cognitarium-client"
+readme = "README.md"
+repository = "https://github.com/axone-protocol/contracts/tree/main/packages/axone-cognitarium-client"
 version = "5.0.0"
 
 [dependencies]

--- a/packages/axone-logic-bindings/Cargo.toml
+++ b/packages/axone-logic-bindings/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
-authors = ["AXONE"]
+authors.workspace = true
+categories = ["cryptography::cryptocurrencies"]
+description = "Package that holds all bindings for querying the AXONE logic module."
+documentation = "https://docs.axone.xyz/modules/logic"
 edition = "2021"
+homepage.workspace = true
+license-file.workspace = true
 name = "axone-logic-bindings"
+readme = "README.md"
+repository = "https://github.com/axone-protocol/contracts/tree/main/packages/axone-logic-bindings"
 version = "5.0.0"
 
 [dependencies]

--- a/packages/axone-objectarium-client/Cargo.toml
+++ b/packages/axone-objectarium-client/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
-authors = ["AXONE"]
+authors.workspace = true
+categories = ["cryptography::cryptocurrencies"]
+description = "Package that holds components to interact with the `axone-objectarium` contract."
+documentation = "https://docs.axone.xyz/contracts/okp4-objectarium"
 edition = "2021"
+homepage.workspace = true
+license-file.workspace = true
 name = "axone-objectarium-client"
+readme = "README.md"
+repository = "https://github.com/axone-protocol/contracts/tree/main/packages/axone-objectarium-client"
 version = "5.0.0"
 
 [dependencies]

--- a/packages/axone-rdf/Cargo.toml
+++ b/packages/axone-rdf/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
-authors = ["AXONE"]
+authors.workspace = true
+categories = ["data-structures", "parser-implementations"]
+description = "Package that holds useful components to manage with `RDF` data, typically reading / writing."
+documentation = "https://docs.axone.xyz/contracts/okp4-cognitarium#model-your-data-with-rdf"
 edition = "2021"
+homepage.workspace = true
+license-file.workspace = true
 name = "axone-rdf"
+readme = "README.md"
+repository = "https://github.com/axone-protocol/contracts/tree/main/packages/axone-rdf"
 version = "5.0.0"
 
 [dependencies]

--- a/packages/axone-wasm/Cargo.toml
+++ b/packages/axone-wasm/Cargo.toml
@@ -1,7 +1,18 @@
 [package]
-authors = ["AXONE"]
+authors.workspace = true
+categories = [
+  "cryptography::cryptocurrencies",
+  "parser-implementations",
+  "data-structures",
+]
+description = "Package that holds useful components to manage with `CosmWasm` data, typically reading / writing."
+documentation = "https://docs.axone.xyz/predicates/open_4#cosmwasm-uri"
 edition = "2021"
+homepage.workspace = true
+license-file.workspace = true
 name = "axone-wasm"
+readme = "README.md"
+repository = "https://github.com/axone-protocol/contracts/tree/main/packages/axone-wasm"
 version = "5.0.0"
 
 [dependencies]

--- a/packages/axone-wasm/README.md
+++ b/packages/axone-wasm/README.md
@@ -1,3 +1,3 @@
-# RDF
+# WASM
 
-Package that holds useful components to manage with `RDF` data, typically reading / writing.
+Package that holds useful components to manage with `CosmWasm` data, typically reading / writing.


### PR DESCRIPTION
Addresses the following Issue
- #527 

Crates.io require that dependencies of a published crate be already published.

<details>
<summary>Error dependency not published</summary>


![Screenshot 2024-06-02 at 22 29 44](https://github.com/axone-protocol/contracts/assets/75730728/16972018-6e2a-43b8-8d45-3f4f20227a42)

</details>


 [Smart-release](https://github.com/Byron/cargo-smart-release) fixes this by taking into consideration the interdependency of the crates. For the moment I've disabled changelog generation and github release but these are features that could be used if wanted.

```mermaid
   %%{init: {'theme': 'neutral', 'themeVariables': {'padding': 20}}}%%
    graph TD;
    subgraph DD[Dependency Diagram]
    axone-law-stone-->axone-objectarium;
    axone-objectarium-client-->axone-objectarium;
    axone-objectarium-client-->axone-wasm;
    axone-logic-bindings-->axone-wasm;
    axone-law-stone-->axone-wasm;
    axone-law-stone-->axone-objectarium-client;
    axone-law-stone-->axone-logic-bindings;

    axone-cognitarium-->axone-rdf;
    axone-dataverse-->axone-rdf;
    axone-dataverse-->axone-cognitarium;
    axone-cognitarium-client-->axone-cognitarium;
    axone-dataverse-->axone-cognitarium-client;
    end
```

I've taken the liberty of filling missing crate manifest fields useful for crate adoption. I leave it up to the team to decide if they're appropriate. 

OBS
- Smart-release requires cmake to run
- There is a list of acceptable categories to chose from on [crates.io](https://crates.io/category_slugs)
- Dependencies declared by path in the workspace manifest do not inherit the crate version as of date. See the following [issue with comments](https://github.com/rust-lang/cargo/issues/11133#issue-1382964697)
- Crates.io requires a token for publishing.
- [keywords](https://doc.rust-lang.org/cargo/reference/manifest.html#the-keywords-field) might be something we'd want to add. For now I leave it at your discretion.
- The publish has not been tested more than doing a dry run. Seeing as there is no crate currently available on crates.io the dry run fails, but should work in prod as the relative crate would have been published just before.

TODO: 
- [ ] [add owner to crate publications](https://doc.rust-lang.org/cargo/reference/publishing.html#cargo-owner)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new GitHub Actions workflow to publish crates to crates.io.
  - Implemented tasks for updating workspace dependency versions and publishing crates.

- **Enhancements**
  - Updated `Cargo.toml` files across multiple packages to include detailed metadata such as authors, homepage, license, documentation, and repository information.
  - Upgraded `edition` to "2021" in relevant `Cargo.toml` files.

- **Documentation**
  - Updated `README.md` for the `axone-wasm` package to reflect new functionality of managing CosmWasm data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->