### PR TITLE
[Objectarium] 🐛 fix: compression size decrement on `forget_object`

### DIFF
--- a/contracts/axone-objectarium/src/contract.rs
+++ b/contracts/axone-objectarium/src/contract.rs
@@ -229,6 +229,7 @@ pub mod execute {
         BUCKET.update(deps.storage, |mut b| -> Result<_, ContractError> {
             b.stat.object_count -= Uint128::one();
             b.stat.size -= object.size;
+            b.stat.compressed_size -= object.compressed_size;
             Ok(b)
         })?;
 


### PR DESCRIPTION
This PR addresses a minor issue identified in security audit #559.  

It introduces a necessary decrement operation for the `total_compressed_size` within the Bucket Stat in addition to the `total_size`, when the `forget_object` message is called. This adjustment ensures accurate tracking of the compressed size, thereby rectifying the discrepancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for storing object data with compression settings.

- **Bug Fixes**
  - Adjusted internal logic to correctly handle compressed sizes and total sizes in various scenarios.

- **Tests**
  - Updated test cases to include `expected_compressed_size` and adjusted expected values for count and total size to ensure accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->