### PR TITLE
Feat/execution without fund

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "cucumber",
  "cw-multi-test",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "derive_builder",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "derive_builder",
  "either",

--- a/contracts/axone-cognitarium/Cargo.toml
+++ b/contracts/axone-cognitarium/Cargo.toml
@@ -23,6 +23,7 @@ cosmwasm-schema.workspace = true
 cosmwasm-std.workspace = true
 cosmwasm-storage.workspace = true
 cw-storage-plus.workspace = true
+cw-utils.workspace = true
 cw2.workspace = true
 derive_builder = "0.20.0"
 either = "1.12.0"

--- a/contracts/axone-cognitarium/src/contract.rs
+++ b/contracts/axone-cognitarium/src/contract.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{
     to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
 };
 use cw2::set_contract_version;
+use cw_utils::nonpayable;
 
 use crate::error::ContractError;
 use crate::msg::{DataFormat, ExecuteMsg, InstantiateMsg, QueryMsg};
@@ -36,6 +37,7 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
+    nonpayable(&info)?;
     match msg {
         ExecuteMsg::InsertData { format, data } => {
             execute::insert(deps, info, format.unwrap_or_default(), data)

--- a/contracts/axone-cognitarium/src/contract.rs
+++ b/contracts/axone-cognitarium/src/contract.rs
@@ -504,7 +504,7 @@ mod tests {
     }
 
     #[test]
-    fn instantiate_fail_with_funds() {
+    fn funds_initialization() {
         let mut deps = mock_dependencies();
         let env = mock_env();
         let info = mock_info("sender", &coins(10, "uaxone"));

--- a/contracts/axone-cognitarium/src/contract.rs
+++ b/contracts/axone-cognitarium/src/contract.rs
@@ -446,12 +446,12 @@ mod tests {
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{coins, from_json, Addr, Attribute, Order, Uint128};
     use cw_utils::PaymentError;
+    use cw_utils::PaymentError::NonPayable;
     use std::collections::BTreeMap;
     use std::fs::File;
     use std::io::Read;
     use std::path::Path;
     use std::{env, u128};
-    use cw_utils::PaymentError::NonPayable;
 
     #[test]
     fn proper_initialization() {

--- a/contracts/axone-cognitarium/src/contract.rs
+++ b/contracts/axone-cognitarium/src/contract.rs
@@ -441,7 +441,8 @@ mod tests {
     };
     use crate::{msg, state};
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{from_json, Addr, Attribute, Order, Uint128};
+    use cosmwasm_std::{coins, from_json, Addr, Attribute, Order, Uint128};
+    use cw_utils::PaymentError;
     use std::collections::BTreeMap;
     use std::fs::File;
     use std::io::Read;
@@ -496,6 +497,34 @@ mod tests {
             BLANK_NODE_IDENTIFIER_COUNTER.load(&deps.storage).unwrap(),
             0u128
         );
+    }
+
+    #[test]
+    fn execute_fail_with_funds() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info("sender", &coins(10, "uaxone"));
+
+        let messages = vec![
+            InsertData {
+                format: Some(DataFormat::RDFXml),
+                data: Binary::from("data".as_bytes()),
+            },
+            DeleteData {
+                prefixes: vec![],
+                delete: vec![],
+                r#where: vec![],
+            },
+        ];
+
+        for msg in messages {
+            let result = execute(deps.as_mut(), env.clone(), info.clone(), msg);
+            assert!(result.is_err());
+            assert_eq!(
+                result.unwrap_err(),
+                ContractError::Payment(PaymentError::NonPayable {})
+            );
+        }
     }
 
     #[test]

--- a/contracts/axone-cognitarium/src/error.rs
+++ b/contracts/axone-cognitarium/src/error.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{StdError, Uint128};
+use cw_utils::PaymentError;
 use rio_turtle::TurtleError;
 use rio_xml::RdfXmlError;
 use thiserror::Error;
@@ -19,6 +20,9 @@ pub enum ContractError {
 
     #[error("Only the owner can perform this operation.")]
     Unauthorized,
+
+    #[error("{0}")]
+    Payment(#[from] PaymentError),
 }
 
 impl From<RdfXmlError> for ContractError {

--- a/contracts/axone-dataverse/src/contract.rs
+++ b/contracts/axone-dataverse/src/contract.rs
@@ -143,11 +143,9 @@ mod tests {
         WhereCondition, IRI,
     };
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{
-        from_json, Addr, Attribute, ContractResult, CosmosMsg, HexBinary, SubMsg, SystemError,
-        SystemResult, Uint128, Uint64, WasmQuery,
-    };
+    use cosmwasm_std::{from_json, Addr, Attribute, ContractResult, CosmosMsg, HexBinary, SubMsg, SystemError, SystemResult, Uint128, Uint64, WasmQuery, coins};
     use std::collections::BTreeMap;
+    use cw_utils::PaymentError;
 
     #[test]
     fn proper_instantiate() {
@@ -235,6 +233,22 @@ mod tests {
                 triplestore_address: Addr::unchecked("my-dataverse-addr"),
             }
         );
+    }
+
+    #[test]
+    fn execute_fail_with_funds() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info("sender", &coins(10, "uaxone"));
+
+        let msg = ExecuteMsg::SubmitClaims {
+            metadata: Binary::from("data".as_bytes()),
+            format: Some(RdfFormat::NQuads),
+        };
+
+        let result = execute(deps.as_mut(), env, info, msg);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ContractError::Payment(PaymentError::NonPayable {})));
     }
 
     #[test]

--- a/contracts/axone-dataverse/src/contract.rs
+++ b/contracts/axone-dataverse/src/contract.rs
@@ -215,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn instantiate_fail_with_funds() {
+    fn funds_initialization() {
         let mut deps = mock_dependencies();
         let env = mock_env();
         let info = mock_info("sender", &coins(10, "uaxone"));

--- a/contracts/axone-dataverse/src/contract.rs
+++ b/contracts/axone-dataverse/src/contract.rs
@@ -5,6 +5,7 @@ use cosmwasm_std::{
     MessageInfo, Response, StdError, StdResult, WasmMsg,
 };
 use cw2::set_contract_version;
+use cw_utils::nonpayable;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
@@ -70,6 +71,7 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
+    nonpayable(&info)?;
     match msg {
         ExecuteMsg::SubmitClaims {
             metadata,
@@ -143,9 +145,12 @@ mod tests {
         WhereCondition, IRI,
     };
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{from_json, Addr, Attribute, ContractResult, CosmosMsg, HexBinary, SubMsg, SystemError, SystemResult, Uint128, Uint64, WasmQuery, coins};
-    use std::collections::BTreeMap;
+    use cosmwasm_std::{
+        coins, from_json, Addr, Attribute, ContractResult, CosmosMsg, HexBinary, SubMsg,
+        SystemError, SystemResult, Uint128, Uint64, WasmQuery,
+    };
     use cw_utils::PaymentError;
+    use std::collections::BTreeMap;
 
     #[test]
     fn proper_instantiate() {
@@ -248,7 +253,10 @@ mod tests {
 
         let result = execute(deps.as_mut(), env, info, msg);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), ContractError::Payment(PaymentError::NonPayable {})));
+        assert!(matches!(
+            result.unwrap_err(),
+            ContractError::Payment(PaymentError::NonPayable {})
+        ));
     }
 
     #[test]

--- a/contracts/axone-dataverse/src/error.rs
+++ b/contracts/axone-dataverse/src/error.rs
@@ -1,6 +1,7 @@
 use crate::credential::error::{InvalidCredentialError, VerificationError};
 use axone_rdf::serde::NQuadsReadError;
 use cosmwasm_std::{Instantiate2AddressError, StdError};
+use cw_utils::PaymentError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -28,4 +29,7 @@ pub enum ContractError {
 
     #[error("An unexpected error occurred: {0}")]
     Unexpected(String),
+
+    #[error("{0}")]
+    Payment(#[from] PaymentError),
 }

--- a/contracts/axone-law-stone/src/contract.rs
+++ b/contracts/axone-law-stone/src/contract.rs
@@ -9,6 +9,7 @@ use cosmwasm_std::{
     WasmMsg,
 };
 use cw2::set_contract_version;
+use cw_utils::nonpayable;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
@@ -57,6 +58,7 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
+    nonpayable(&info)?;
     match msg {
         ExecuteMsg::BreakStone => execute::break_stone(deps, env, info),
     }
@@ -291,9 +293,9 @@ mod tests {
         Order, OwnedDeps, SubMsgResponse, SubMsgResult, SystemError, SystemResult, WasmQuery,
     };
     use cw_utils::ParseReplyError::SubMsgFailure;
+    use cw_utils::PaymentError;
     use std::collections::VecDeque;
     use std::marker::PhantomData;
-    use cw_utils::PaymentError;
 
     fn custom_logic_handler_with_dependencies(
         dependencies: Vec<String>,
@@ -867,7 +869,10 @@ mod tests {
             ExecuteMsg::BreakStone,
         );
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), ContractError::Payment(PaymentError::NonPayable {}));
+        assert_eq!(
+            result.unwrap_err(),
+            ContractError::Payment(PaymentError::NonPayable {})
+        );
     }
 
     #[test]

--- a/contracts/axone-law-stone/src/contract.rs
+++ b/contracts/axone-law-stone/src/contract.rs
@@ -287,12 +287,13 @@ mod tests {
         MockQuerierCustomHandlerResult, MockStorage,
     };
     use cosmwasm_std::{
-        from_json, to_json_binary, ContractInfoResponse, ContractResult, CosmosMsg, Event, Order,
-        OwnedDeps, SubMsgResponse, SubMsgResult, SystemError, SystemResult, WasmQuery,
+        coins, from_json, to_json_binary, ContractInfoResponse, ContractResult, CosmosMsg, Event,
+        Order, OwnedDeps, SubMsgResponse, SubMsgResult, SystemError, SystemResult, WasmQuery,
     };
     use cw_utils::ParseReplyError::SubMsgFailure;
     use std::collections::VecDeque;
     use std::marker::PhantomData;
+    use cw_utils::PaymentError;
 
     fn custom_logic_handler_with_dependencies(
         dependencies: Vec<String>,
@@ -851,6 +852,22 @@ mod tests {
             }
             _ => panic!("Expected Ok(LogicCustomQuery)."),
         }
+    }
+
+    #[test]
+    fn execute_fail_with_funds() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info("sender", &coins(10, "uaxone"));
+
+        let result = execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            ExecuteMsg::BreakStone,
+        );
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), ContractError::Payment(PaymentError::NonPayable {}));
     }
 
     #[test]

--- a/contracts/axone-law-stone/src/contract.rs
+++ b/contracts/axone-law-stone/src/contract.rs
@@ -390,7 +390,7 @@ mod tests {
     }
 
     #[test]
-    fn instantiate_fail_with_funds() {
+    fn funds_initialization() {
         let mut deps =
             mock_dependencies_with_logic_handler(|_| SystemResult::Err(SystemError::Unknown {}));
         let env = mock_env();

--- a/contracts/axone-law-stone/src/error.rs
+++ b/contracts/axone-law-stone/src/error.rs
@@ -1,7 +1,7 @@
 use axone_logic_bindings::error::TermParseError;
 use axone_wasm::error::CosmwasmUriError;
 use cosmwasm_std::StdError;
-use cw_utils::ParseReplyError;
+use cw_utils::{ParseReplyError, PaymentError};
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -23,6 +23,9 @@ pub enum ContractError {
 
     #[error("Only the contract admin can perform this operation.")]
     Unauthorized,
+
+    #[error("{0}")]
+    Payment(#[from] PaymentError),
 }
 
 #[derive(Error, Debug, PartialEq, Eq)]

--- a/contracts/axone-objectarium/Cargo.toml
+++ b/contracts/axone-objectarium/Cargo.toml
@@ -23,6 +23,7 @@ cosmwasm-schema.workspace = true
 cosmwasm-std.workspace = true
 cosmwasm-storage.workspace = true
 cw-storage-plus.workspace = true
+cw-utils.workspace = true
 cw2.workspace = true
 derive_builder = "0.20.0"
 either = "1.12.0"

--- a/contracts/axone-objectarium/src/contract.rs
+++ b/contracts/axone-objectarium/src/contract.rs
@@ -3,6 +3,7 @@ use crate::error::BucketError;
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw2::set_contract_version;
+use cw_utils::nonpayable;
 
 use crate::crypto;
 use crate::error::ContractError;
@@ -42,6 +43,8 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
+    nonpayable(&info)?;
+
     match msg {
         ExecuteMsg::StoreObject {
             data,
@@ -434,6 +437,7 @@ mod tests {
     use cosmwasm_std::StdError::NotFound;
     use cosmwasm_std::{coins, from_json, Addr, Attribute, Order, StdError, Uint128};
     use cw_utils::PaymentError;
+
     use std::any::type_name;
 
     fn decode_hex(hex: &str) -> Vec<u8> {

--- a/contracts/axone-objectarium/src/error.rs
+++ b/contracts/axone-objectarium/src/error.rs
@@ -1,6 +1,7 @@
 use crate::compress::CompressionError;
 use crate::msg::CompressionAlgorithm;
 use cosmwasm_std::{StdError, Uint128};
+use cw_utils::PaymentError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -16,6 +17,9 @@ pub enum ContractError {
 
     #[error("Compression error: {0}")]
     CompressionError(String),
+
+    #[error("{0}")]
+    Payment(#[from] PaymentError),
 }
 
 #[derive(Error, Debug, Eq, PartialEq)]


### PR DESCRIPTION
This PR introduces the implementation of the security audit recommendation #562. The main focus of these changes is to ensure no funds are sent when trying to execute contract messages.

Key changes include:

1. A check has been added in the `execute` function in `contract.rs` to ensure no funds are sent during the execution of contract messages. If funds are detected, the function will return an error of type `ContractError::Payment(PaymentError::NonPayable)`. The implementation has been duplicate for all contracts (`dataverse`, `cognitarium`, `objectarium` and `law-stone`)

2. The same check has been added on all `instantiate` function for all contract.  

3. Test cases have been added to validate this new functionality. These tests iterate over all `ExecuteMsg` variants and attempt to execute each one with funds, expecting each execution to fail with the `ContractError::Payment(PaymentError::NonPayable)` error. And the same for Instantiate.

This PR aims to prevent unintended fund transfers during contract execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced checks for empty funds in various contract execution functions to ensure proper handling of transactions without funds.
  - Added new error variants for handling payment-related errors across different modules.

- **Tests**
  - Added new test functions to validate scenarios involving fund checks and non-payable funds.

- **Chores**
  - Updated dependencies in `Cargo.toml` to include `cw-utils`.

These changes enhance the robustness of transaction handling and error reporting across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->