### PR TITLE
Refactor/rationalize objectarium api

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,6 +4,25 @@ branches:
 plugins:
   - - "@semantic-release/commit-analyzer"
     - preset: conventionalcommits
+      releaseRules:
+        - type: build
+          scope: deps
+          release: patch
+        - type: build
+          scope: deps-dev
+          release: patch
+        - type: refactor
+          release: patch
+        - type: style
+          release: patch
+        - type: ci
+          release: patch
+        - type: chore
+          release: patch
+        - type: docs
+          release: patch
+        - breaking: true
+          release: major
   - - "@semantic-release/release-notes-generator"
     - preset: conventionalcommits
   - - "@semantic-release/changelog"

--- a/contracts/axone-objectarium/src/msg.rs
+++ b/contracts/axone-objectarium/src/msg.rs
@@ -81,7 +81,7 @@ pub enum QueryMsg {
     /// # Bucket
     /// Bucket returns the bucket information.
     #[returns(BucketResponse)]
-    Bucket {},
+    Bucket,
 
     /// # Object
     /// Object returns the object information with the given id.

--- a/docs/axone-objectarium.md
+++ b/docs/axone-objectarium.md
@@ -212,9 +212,9 @@ Query messages
 
 Bucket returns the bucket information.
 
-| parameter | description                |
-| --------- | -------------------------- |
-| `bucket`  | _(Required.) _ **object**. |
+| literal    |
+| ---------- |
+| `"bucket"` |
 
 ### QueryMsg::Object
 
@@ -511,4 +511,4 @@ A string containing a 128-bit integer in decimal representation.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-objectarium.json` (`7767f03132c85cdd`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-objectarium.json` (`b5ee98f050799330`)_


### PR DESCRIPTION
Low value, not a big deal but that's breaking so I thought the sooner the better :)

Remove the empty parameters of the `bucket` query in the objectarium contract, easier to use and by consistency with other similar queries in other contracts.

The corresponding json query is now `"bucket"` (previously `{"bucket":{}}`).

I also took the opportunity to fine tune the release commit analyser to properly trigger a breaking change on refactor commits, as this one :).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated parameter description format and rendered version information in the query messages section of the documentation.
  
- **Refactor**
  - Simplified the definition of the `Bucket` variant in the `QueryMsg` enum.

- **Chores**
  - Introduced new release rules for different commit types in the release configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->