### PR TITLE
Refactor/rationalize empty msg api

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,6 +4,25 @@ branches:
 plugins:
   - - "@semantic-release/commit-analyzer"
     - preset: conventionalcommits
+      releaseRules:
+        - type: build
+          scope: deps
+          release: patch
+        - type: build
+          scope: deps-dev
+          release: patch
+        - type: refactor
+          release: patch
+        - type: style
+          release: patch
+        - type: ci
+          release: patch
+        - type: chore
+          release: patch
+        - type: docs
+          release: patch
+        - breaking: true
+          release: major
   - - "@semantic-release/release-notes-generator"
     - preset: conventionalcommits
   - - "@semantic-release/changelog"

--- a/contracts/axone-cognitarium/src/contract.rs
+++ b/contracts/axone-cognitarium/src/contract.rs
@@ -159,7 +159,7 @@ pub mod execute {
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps<'_>, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Store => to_json_binary(&query::store(deps)?),
+        QueryMsg::Store {} => to_json_binary(&query::store(deps)?),
         QueryMsg::Select { query } => to_json_binary(&query::select(deps, query)?),
         QueryMsg::Describe { query, format } => {
             to_json_binary(&query::describe(deps, query, format.unwrap_or_default())?)
@@ -1249,7 +1249,7 @@ mod tests {
             )
             .unwrap();
 
-        let res = query(deps.as_ref(), mock_env(), QueryMsg::Store);
+        let res = query(deps.as_ref(), mock_env(), QueryMsg::Store {});
         assert!(res.is_ok());
         assert_eq!(
             from_json::<StoreResponse>(&res.unwrap()).unwrap(),

--- a/contracts/axone-cognitarium/src/msg.rs
+++ b/contracts/axone-cognitarium/src/msg.rs
@@ -85,7 +85,7 @@ pub enum QueryMsg {
     ///
     /// Returns information about the triple store.
     #[returns(StoreResponse)]
-    Store,
+    Store {},
 
     /// # Select
     ///

--- a/contracts/axone-law-stone/src/contract.rs
+++ b/contracts/axone-law-stone/src/contract.rs
@@ -61,7 +61,7 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     nonpayable(&info)?;
     match msg {
-        ExecuteMsg::BreakStone => execute::break_stone(deps, env, info),
+        ExecuteMsg::BreakStone {} => execute::break_stone(deps, env, info),
     }
 }
 
@@ -125,8 +125,8 @@ pub mod execute {
 pub fn query(deps: Deps<'_, LogicCustomQuery>, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Ask { query } => to_json_binary(&query::ask(deps, env, query)?),
-        QueryMsg::Program => to_json_binary(&query::program(deps)?),
-        QueryMsg::ProgramCode => to_json_binary(&query::program_code(deps)?),
+        QueryMsg::Program {} => to_json_binary(&query::program(deps)?),
+        QueryMsg::ProgramCode {} => to_json_binary(&query::program_code(deps)?),
     }
 }
 
@@ -886,7 +886,7 @@ mod tests {
             deps.as_mut(),
             env.clone(),
             info.clone(),
-            ExecuteMsg::BreakStone,
+            ExecuteMsg::BreakStone {},
         );
         assert!(result.is_err());
         assert_eq!(
@@ -979,7 +979,7 @@ mod tests {
                 deps.as_mut(),
                 mock_env(),
                 info.clone(),
-                ExecuteMsg::BreakStone,
+                ExecuteMsg::BreakStone {},
             )
             .unwrap();
 
@@ -1089,7 +1089,7 @@ mod tests {
                 deps.as_mut(),
                 mock_env(),
                 mock_info(case.0, &[]),
-                ExecuteMsg::BreakStone,
+                ExecuteMsg::BreakStone {},
             );
 
             match case.3 {
@@ -1141,7 +1141,7 @@ mod tests {
             deps.as_mut(),
             mock_env(),
             mock_info("creator", &[]),
-            ExecuteMsg::BreakStone,
+            ExecuteMsg::BreakStone {},
         );
         assert!(res.is_ok());
         assert_eq!(res.ok().unwrap().messages.len(), 0);

--- a/contracts/axone-law-stone/src/msg.rs
+++ b/contracts/axone-law-stone/src/msg.rs
@@ -22,7 +22,7 @@ pub enum ExecuteMsg {
     /// - Forget the main program (i.e. or at least unpin it).
     /// Only the contract admin is authorized to break it, if any.
     /// If already broken, this is a no-op.
-    BreakStone,
+    BreakStone {},
 }
 
 /// Query messages
@@ -44,7 +44,7 @@ pub enum QueryMsg {
     /// This includes the contract address of the `objectarium` and the program object ID,
     /// where the law program's code can be accessed.
     #[returns(ProgramResponse)]
-    Program,
+    Program {},
 
     /// # ProgramCode
     /// Fetches the raw code of the law program tied to this contract.
@@ -52,7 +52,7 @@ pub enum QueryMsg {
     /// If the law stone is broken, the query may fail if the program is no longer available in the
     /// `Objectarium`.
     #[returns(Binary)]
-    ProgramCode,
+    ProgramCode {},
 }
 
 /// # ProgramResponse

--- a/docs/axone-cognitarium.md
+++ b/docs/axone-cognitarium.md
@@ -430,9 +430,9 @@ Query messages
 
 Returns information about the triple store.
 
-| literal   |
-| --------- |
-| `"store"` |
+| parameter | description                |
+| --------- | -------------------------- |
+| `store`   | _(Required.) _ **object**. |
 
 ### QueryMsg::Select
 
@@ -876,4 +876,4 @@ Represents a condition in a [WhereClause].
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-cognitarium.json` (`ddcfdef446357b86`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-cognitarium.json` (`72125c91d0c7acd2`)_

--- a/docs/axone-law-stone.md
+++ b/docs/axone-law-stone.md
@@ -31,9 +31,9 @@ Execute messages
 
 Break the stone making this contract unusable, by clearing all the related resources: - Unpin all the pinned objects on `axone-objectarium` contracts, if any. - Forget the main program (i.e. or at least unpin it). Only the contract admin is authorized to break it, if any. If already broken, this is a no-op.
 
-| literal         |
-| --------------- |
-| `"break_stone"` |
+| parameter     | description                |
+| ------------- | -------------------------- |
+| `break_stone` | _(Required.) _ **object**. |
 
 ## QueryMsg
 
@@ -56,9 +56,9 @@ Retrieves the location metadata of the law program bound to this contract.
 
 This includes the contract address of the `objectarium` and the program object ID, where the law program's code can be accessed.
 
-| literal     |
-| ----------- |
-| `"program"` |
+| parameter | description                |
+| --------- | -------------------------- |
+| `program` | _(Required.) _ **object**. |
 
 ### QueryMsg::ProgramCode
 
@@ -66,9 +66,9 @@ Fetches the raw code of the law program tied to this contract.
 
 If the law stone is broken, the query may fail if the program is no longer available in the `Objectarium`.
 
-| literal          |
-| ---------------- |
-| `"program_code"` |
+| parameter      | description                |
+| -------------- | -------------------------- |
+| `program_code` | _(Required.) _ **object**. |
 
 ## Responses
 
@@ -134,4 +134,4 @@ A string containing Base64-encoded data.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-law-stone.json` (`96a9a3b253c6a3fc`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-law-stone.json` (`a0a965a7234a8b34`)_


### PR DESCRIPTION
For consistency and to align with the practices in the cw ecosystem, this PR update the messages APIs adding empty parameters to variant without parameters. This is a breaking change.

## Details

The following JSON messages have changes:
- Cognitarium store query: "store" => {"store":{}});
- Law stone program query: "program" => {"program":{}});
- Law stone break stone exec: "break_stone" => {"break_stone":{}});

## Misc

I also took the opportunity to fine tune the release commit analyser to properly trigger a breaking change on refactor commits, as this one :).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated descriptions and table structures for parameters in `axone-cognitarium.md` and `axone-law-stone.md` to improve clarity and readability.

- **Refactor**
  - Modified pattern matching in `axone-cognitarium` and `axone-law-stone` contracts to use struct-like syntax for `QueryMsg` and `ExecuteMsg` variants, enhancing code consistency.
  
- **Chores**
  - Updated `.releaserc.yml` to include specific release rules for various commit types and major release triggers for breaking changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->