### PR TITLE
fix(law-stone)!: ensure only the creator can break the stone (was admin)

### DIFF
--- a/contracts/axone-law-stone/src/msg.rs
+++ b/contracts/axone-law-stone/src/msg.rs
@@ -20,7 +20,9 @@ pub enum ExecuteMsg {
     /// Break the stone making this contract unusable, by clearing all the related resources:
     /// - Unpin all the pinned objects on `axone-objectarium` contracts, if any.
     /// - Forget the main program (i.e. or at least unpin it).
-    /// Only the contract admin is authorized to break it, if any.
+    ///
+    /// Only the creator address (the address that instantiated the contract) is authorized to invoke
+    /// this message.
     /// If already broken, this is a no-op.
     BreakStone {},
 }

--- a/docs/axone-law-stone.md
+++ b/docs/axone-law-stone.md
@@ -29,7 +29,9 @@ Execute messages
 
 ### ExecuteMsg::BreakStone
 
-Break the stone making this contract unusable, by clearing all the related resources: - Unpin all the pinned objects on `axone-objectarium` contracts, if any. - Forget the main program (i.e. or at least unpin it). Only the contract admin is authorized to break it, if any. If already broken, this is a no-op.
+Break the stone making this contract unusable, by clearing all the related resources: - Unpin all the pinned objects on `axone-objectarium` contracts, if any. - Forget the main program (i.e. or at least unpin it).
+
+Only the creator address (the address that instantiated the contract) is authorized to invoke this message. If already broken, this is a no-op.
 
 | parameter     | description                |
 | ------------- | -------------------------- |
@@ -134,4 +136,4 @@ A string containing Base64-encoded data.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-law-stone.json` (`a0a965a7234a8b34`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-law-stone.json` (`58a14576c3c1d7fe`)_


### PR DESCRIPTION
Addresses #552. Ensure that *only* `creator` address (the address that instantiated the contract) is authorized to break the stone instead of the `admin`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `BreakStone` functionality to restrict invocation to the contract creator, enhancing security and control.

- **Documentation**
	- Clarified the `BreakStone` message authorization process and behavior in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->