### PR TITLE
🔔 Notify `axone-contract-schema` update

### DIFF
--- a/.github/workflows/notify-draft.yml
+++ b/.github/workflows/notify-draft.yml
@@ -26,20 +26,20 @@ jobs:
               }
             }
 
-#  update-schema:
-#    runs-on: ubuntu-22.04
-#    steps:
-#      - name: Update draft docs repository
-#        uses: fjogeleit/http-request-action@v1
-#        with:
-#          url: 'https://api.github.com/repos/okp4/okp4-contract-schema/actions/workflows/68383422/dispatches'
-#          method: 'POST'
-#          customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
-#          data: |-
-#            {
-#              "ref": "main",
-#              "inputs": {
-#                "ref": "main",
-#                "draft": "true"
-#              }
-#            }
+  update-schema:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Update draft docs repository
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.github.com/repos/axone-protocol/axone-contract-schema/actions/workflows/68383422/dispatches'
+          method: 'POST'
+          customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
+          data: |-
+            {
+              "ref": "main",
+              "inputs": {
+                "ref": "main",
+                "draft": "true"
+              }
+            }

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -42,20 +42,20 @@ jobs:
               }
             }
 
-#  update-schema:
-#    runs-on: ubuntu-22.04
-#    steps:
-#      - name: Update schema repository
-#        uses: fjogeleit/http-request-action@v1
-#        with:
-#          url: 'https://api.github.com/repos/okp4/okp4-contract-schema/actions/workflows/68383422/dispatches'
-#          method: 'POST'
-#          customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
-#          data: |-
-#            {
-#              "ref": "main",
-#              "inputs": {
-#                "ref": "${{ github.event.release.tag_name }}",
-#                "draft": "false"
-#              }
-#            }
+  update-schema:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Update schema repository
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.github.com/repos/axone-protocol/axone-contract-schema/actions/workflows/68383422/dispatches'
+          method: 'POST'
+          customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
+          data: |-
+            {
+              "ref": "main",
+              "inputs": {
+                "ref": "${{ github.event.release.tag_name }}",
+                "draft": "false"
+              }
+            }


### PR DESCRIPTION
Restores the workflow that triggers the schema update [workflow](https://github.com/axone-protocol/axone-contract-schema/actions/workflows/update-schema.yml) in the [`axone-contract-schema`](https://github.com/axone-protocol/axone-contract-schema) repository. Please note that the workflow ID has remained unchanged since the migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated repository URLs in GitHub workflows for schema updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->