### PR TITLE
👷 Add GitHub discussion Notification for releases

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -2,7 +2,7 @@ name: notify-release
 
 on:
   release:
-    types: [ published ]
+    types: [published]
 
 jobs:
   notify-discord:
@@ -12,7 +12,7 @@ jobs:
         uses: fjogeleit/http-request-action@v1
         with:
           url: ${{ secrets.DISCORD_WEBHOOK }}
-          method: 'POST'
+          method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
           data: |-
             {
@@ -21,14 +21,31 @@ jobs:
               "content": "🚨 A new version of @${{ github.repository }} ${{ github.event.release.tag_name }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\n👉 Official repo: https://github.com/${{ github.repository }}"
             }
 
+  notify-github-discussion:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Post announcement to GitHub Discussion
+        uses: abirismyname/create-discussion@v1
+        env:
+          GH_TOKEN: ${{ secrets.OPS_TOKEN }}
+        with:
+          title: "🎉 ${{ github.repository }} ${{ github.event.release.tag_name }} has been released"
+          body: |
+            🎉 [${{ github.repository }}](https://github.com/${{ github.repository }}) ${{ github.event.release.tag_name }} has been released!
+
+            👉 Changelog: <https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}>
+            👉 Official repo: <https://github.com/${{ github.repository }}>
+          repository-id: "R_kgDOLsWt6A"
+          category-id: "DIC_kwDOLsWt6M4CemGO"
+
   update-docs:
     runs-on: ubuntu-22.04
     steps:
       - name: Update docs repository
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://api.github.com/repos/axone-protocol/docs/actions/workflows/39152549/dispatches'
-          method: 'POST'
+          url: "https://api.github.com/repos/axone-protocol/docs/actions/workflows/39152549/dispatches"
+          method: "POST"
           customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
           data: |-
             {
@@ -48,8 +65,8 @@ jobs:
       - name: Update schema repository
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://api.github.com/repos/axone-protocol/axone-contract-schema/actions/workflows/68383422/dispatches'
-          method: 'POST'
+          url: "https://api.github.com/repos/axone-protocol/axone-contract-schema/actions/workflows/68383422/dispatches"
+          method: "POST"
           customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
           data: |-
             {


### PR DESCRIPTION
Addresses https://github.com/axone-protocol/community/issues/6 by adding a new job to post an announcement in our [GitHub Discussions](https://github.com/orgs/axone-protocol/discussions/categories/announcements) .


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new job to post announcements to GitHub discussions.

- **Chores**
  - Updated formatting and syntax in the release workflow configuration for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->