### PR TITLE
⬆ Bump cosmwasm 2.0.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +22,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anstream"
@@ -62,9 +80,130 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "num-traits",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rayon",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+ "rayon",
+]
 
 [[package]]
 name = "arrayref"
@@ -92,7 +231,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "cosmwasm-storage",
  "cucumber",
  "cw-multi-test",
@@ -117,7 +256,7 @@ name = "axone-cognitarium-client"
 version = "6.0.0"
 dependencies = [
  "axone-cognitarium",
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "serde",
 ]
 
@@ -131,7 +270,7 @@ dependencies = [
  "base64 0.22.1",
  "bs58",
  "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus",
@@ -158,7 +297,7 @@ dependencies = [
  "axone-objectarium-client",
  "axone-wasm",
  "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus",
@@ -176,7 +315,7 @@ name = "axone-logic-bindings"
 version = "6.0.0"
 dependencies = [
  "axone-wasm",
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "form_urlencoded",
  "schemars",
  "serde",
@@ -193,7 +332,7 @@ dependencies = [
  "base64 0.22.1",
  "bs58",
  "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus",
@@ -217,7 +356,7 @@ version = "6.0.0"
 dependencies = [
  "axone-objectarium",
  "axone-wasm",
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "schemars",
  "serde",
 ]
@@ -227,7 +366,7 @@ name = "axone-rdf"
 version = "6.0.0"
 dependencies = [
  "base16ct",
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "itertools 0.13.0",
  "rio_api",
  "rio_turtle",
@@ -240,7 +379,7 @@ dependencies = [
 name = "axone-wasm"
 version = "6.0.0"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "form_urlencoded",
  "schemars",
  "serde",
@@ -286,6 +425,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
 name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,9 +469,15 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.10.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
+checksum = "ab9008b6bb9fc80b5277f2fe481c09e828743d9151203e804583eb4c9e15b31d"
+
+[[package]]
+name = "bnum"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 
 [[package]]
 name = "bs58"
@@ -450,16 +601,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
-name = "cosmwasm-crypto"
-version = "1.5.5"
+name = "cosmwasm-core"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd50718a2b6830ce9eb5d465de5a018a12e71729d66b70807ce97e6dd14f931d"
+checksum = "367fc87c43759098a476ef90f915aadc66c300480ad9c155b512081fbf327bc1"
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6aa9f904de106fa16443ad14ec2abe75e94ba003bb61c681c0e43d4c58d2a"
 dependencies = [
  "digest 0.10.7",
  "ecdsa",
- "ed25519-zebra",
+ "ed25519-zebra 3.0.0",
  "k256",
  "rand_core 0.6.4",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7c41f3e371ea457d3b98bb592c38858b46efcf614e0e988ec2ebbdb973954f"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "cosmwasm-core",
+ "digest 0.10.7",
+ "ecdsa",
+ "ed25519-zebra 4.0.3",
+ "k256",
+ "num-traits",
+ "p256",
+ "rand_core 0.6.4",
+ "rayon",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -473,10 +653,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmwasm-schema"
-version = "1.5.5"
+name = "cosmwasm-derive"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7879036156092ad1c22fe0d7316efc5a5eceec2bc3906462a2560215f2a2f929"
+checksum = "c10510e8eb66cf7e109741b1e2c76ad18f30b5a1daa064f5f7115c1f733aaea0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
+name = "cosmwasm-schema"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79879b6b7ef6a331b05030ce91ce46a7c4b0baf1ed6b382cce2e9a168109380"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -487,26 +678,26 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.5.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb57855fbfc83327f8445ae0d413b1a05ac0d68c396ab4d122b2abd7bb82cb6"
+checksum = "82b53e33c0e97170c7ac9cb440f4bc599a07f9cbb9b7e87916cca37b1239d57b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.46",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.5"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c1556156fdf892a55cced6115968b961eaaadd6f724a2c2cb7d1e168e32dd3"
+checksum = "ad011ae7447188e26e4a7dbca2fcd0fc186aa21ae5c86df0503ea44c78f9e469"
 dependencies = [
  "base64 0.21.7",
- "bech32",
- "bnum",
- "cosmwasm-crypto",
- "cosmwasm-derive",
+ "bech32 0.9.1",
+ "bnum 0.8.1",
+ "cosmwasm-crypto 1.5.2",
+ "cosmwasm-derive 1.5.5",
  "derivative",
  "forward_ref",
  "hex",
@@ -519,12 +710,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-std"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92011c39570876f340d5f9defa68bf92797b1c44421f1b9ea9b04a31d6defd33"
+dependencies = [
+ "base64 0.22.1",
+ "bech32 0.11.0",
+ "bnum 0.11.0",
+ "cosmwasm-core",
+ "cosmwasm-crypto 2.1.1",
+ "cosmwasm-derive 2.1.1",
+ "derive_more 1.0.0-beta.6",
+ "hex",
+ "rand_core 0.6.4",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "sha2 0.10.8",
+ "static_assertions",
+ "thiserror",
+]
+
+[[package]]
 name = "cosmwasm-storage"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66de2ab9db04757bcedef2b5984fbe536903ada4a8a9766717a4a71197ef34f6"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.5.2",
  "serde",
 ]
 
@@ -610,7 +824,7 @@ dependencies = [
  "console",
  "cucumber-codegen",
  "cucumber-expressions",
- "derive_more",
+ "derive_more 0.99.17",
  "drain_filter_polyfill",
  "either",
  "futures",
@@ -650,7 +864,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d794fed319eea24246fb5f57632f7ae38d61195817b7eb659455aa5bdd7c1810"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.17",
  "either",
  "nom",
  "nom_locate",
@@ -672,18 +886,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-multi-test"
-version = "0.20.1"
+name = "curve25519-dalek"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc392a5cb7e778e3f90adbf7faa43c4db7f35b6623224b08886d796718edb875"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
+name = "cw-multi-test"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0034bfb4c06dfc8b50f0b1a06c3fc0f2312a1bae568a97db65930de071288ba"
 dependencies = [
  "anyhow",
- "bech32",
- "cosmwasm-std",
+ "bech32 0.11.0",
+ "cosmwasm-std 2.1.1",
  "cw-storage-plus",
  "cw-utils",
  "derivative",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "prost",
  "schemars",
  "serde",
@@ -693,40 +934,39 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ff29294ee99373e2cd5fd21786a3c0ced99a52fec2ca347d565489c61b723c"
+checksum = "f13360e9007f51998d42b1bc6b7fa0141f74feae61ed5fd1e5b0a89eec7b5de1"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw-utils"
-version = "1.0.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4a657e5caacc3a0d00ee96ca8618745d050b8f757c709babafb81208d4239c"
+checksum = "07dfee7f12f802431a856984a32bce1cb7da1e6c006b5409e3981035ce562dec"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std",
- "cw2",
+ "cosmwasm-std 2.1.1",
  "schemars",
- "semver",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "cw2"
-version = "1.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9431d14f64f49e41c6ef5561ed11a5391c417d0cb16455dea8cdcb9037a8d197"
+checksum = "b04852cd38f044c0751259d5f78255d07590d136b8a86d4e09efdd7666bd6d27"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-std 2.1.1",
  "cw-storage-plus",
  "schemars",
+ "semver",
  "serde",
  "thiserror",
 ]
@@ -856,6 +1096,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,17 +1164,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
 name = "ed25519-zebra"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "hex",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
  "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-zebra"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519",
+ "hashbrown 0.14.5",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.10.8",
  "zeroize",
 ]
 
@@ -993,6 +1278,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fnv"
@@ -1191,9 +1482,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1267,7 +1571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1323,9 +1627,9 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -1453,10 +1757,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
+name = "num-bigint"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -1475,6 +1807,24 @@ name = "oxiri"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb175ec8981211357b7b379869c2f8d555881c55ea62311428ec0de46d89bd5c"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peg"
@@ -1552,19 +1902,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.76"
+name = "ppv-lite86"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+dependencies = [
+ "zerocopy 0.6.6",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1572,12 +1940,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.46",
@@ -1602,6 +1970,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +2005,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.12",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1691,6 +2099,15 @@ dependencies = [
  "oxiri",
  "quick-xml",
  "rio_api",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1773,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -2122,6 +2539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,7 +2750,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
+name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ dependencies = [
  "schemars",
  "serde",
  "sha2 0.10.8",
+ "testing",
  "thiserror",
  "unsigned-varint",
  "url",
@@ -2431,6 +2432,13 @@ checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "testing"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-std 2.1.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "testing",
  "thiserror",
 ]
 
@@ -307,6 +308,7 @@ dependencies = [
  "itertools 0.13.0",
  "schemars",
  "serde",
+ "testing",
  "thiserror",
  "url",
 ]
@@ -348,6 +350,7 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "snap",
+ "testing",
  "thiserror",
 ]
 
@@ -2436,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.1.0"
+version = "5.0.0"
 dependencies = [
  "cosmwasm-std 2.1.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ axone-objectarium = { path = "contracts/axone-objectarium", features = [
 axone-objectarium-client = { path = "packages/axone-objectarium-client" }
 axone-rdf = { path = "packages/axone-rdf" }
 axone-wasm = { path = "packages/axone-wasm" }
-cosmwasm-schema = "1.5.5"
-cosmwasm-std = { version = "1.5.5", features = ["cosmwasm_1_2"] }
+cosmwasm-schema = "2.0.4"
+cosmwasm-std = { version = "2.0.4", features = ["cosmwasm_2_0"] }
 cosmwasm-storage = "1.5.2"
-cw-multi-test = "0.20.1"
-cw-storage-plus = "1.2.0"
-cw-utils = "1.0.3"
-cw2 = "1.1.1"
+cw-multi-test = "2.1.0"
+cw-storage-plus = "2.0.0"
+cw-utils = "2.0.0"
+cw2 = "2.0.0"
 iref = "3.1.3"
 langtag = "0.3.4"
 rdf-types = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,5 @@ rio_xml = "0.8.4"
 schemars = "0.8.21"
 serde = { version = "1.0.204", default-features = false, features = ["derive"] }
 serde-json-wasm = "1.0.1"
+testing = { path = "packages/testing" }
 thiserror = { version = "1.0.63" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ axone-objectarium = { path = "contracts/axone-objectarium", features = [
 axone-objectarium-client = { path = "packages/axone-objectarium-client" }
 axone-rdf = { path = "packages/axone-rdf" }
 axone-wasm = { path = "packages/axone-wasm" }
-cosmwasm-schema = "2.0.4"
-cosmwasm-std = { version = "2.0.4", features = ["cosmwasm_2_0"] }
+cosmwasm-schema = "2.1.1"
+cosmwasm-std = { version = "2.1.1", features = ["cosmwasm_2_1"] }
 cosmwasm-storage = "1.5.2"
 cw-multi-test = "2.1.0"
 cw-storage-plus = "2.0.0"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -624,7 +624,7 @@ install_crate = { crate_name = "cargo-llvm-cov", min_version = "0.6.9" }
 install_crate_args = ["--force"]
 
 [tasks.install-cosmwasm-check]
-install_crate = { crate_name = "cosmwasm-check", min_version = "1.5.3" }
+install_crate = { crate_name = "cosmwasm-check", min_version = "2.1.1" }
 
 [tasks.install-ffizer]
 install_script = '''

--- a/contracts/axone-cognitarium/Cargo.toml
+++ b/contracts/axone-cognitarium/Cargo.toml
@@ -41,6 +41,7 @@ cw-multi-test.workspace = true
 futures = "0.3.30"
 serde_json = "1.0.121"
 serde_yaml = "0.9.34"
+testing.workspace = true
 
 [features]
 # use library feature to disable all instantiate/execute/query exports

--- a/contracts/axone-cognitarium/Cargo.toml
+++ b/contracts/axone-cognitarium/Cargo.toml
@@ -43,8 +43,6 @@ serde_json = "1.0.121"
 serde_yaml = "0.9.34"
 
 [features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 

--- a/contracts/axone-cognitarium/src/contract.rs
+++ b/contracts/axone-cognitarium/src/contract.rs
@@ -443,7 +443,7 @@ mod tests {
         namespaces, triples, Namespace, Node, Object, StoreLimits, StoreStat, Subject, Triple,
     };
     use crate::{msg, state};
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
     use cosmwasm_std::{coins, from_json, Addr, Attribute, Order, Uint128};
     use cw_utils::PaymentError;
     use cw_utils::PaymentError::NonPayable;
@@ -452,6 +452,7 @@ mod tests {
     use std::io::Read;
     use std::path::Path;
     use std::{env, u128};
+    use testing::addr::{addr, OWNER, SENDER};
 
     #[test]
     fn proper_initialization() {
@@ -469,7 +470,7 @@ mod tests {
             },
         };
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
         assert_eq!(0, res.messages.len());
 
@@ -507,7 +508,7 @@ mod tests {
     fn funds_initialization() {
         let mut deps = mock_dependencies();
         let env = mock_env();
-        let info = mock_info("sender", &coins(10, "uaxone"));
+        let info = message_info(&addr(SENDER), &coins(10, "uaxone"));
 
         let msg = InstantiateMsg::default();
 
@@ -520,7 +521,7 @@ mod tests {
     fn execute_fail_with_funds() {
         let mut deps = mock_dependencies();
         let env = mock_env();
-        let info = mock_info("sender", &coins(10, "uaxone"));
+        let info = message_info(&addr("sender"), &coins(10, "uaxone"));
 
         let messages = vec![
             InsertData {
@@ -572,7 +573,7 @@ mod tests {
         for case in cases {
             let mut deps = mock_dependencies();
 
-            let info = mock_info("owner", &[]);
+            let info = message_info(&addr(OWNER), &[]);
             instantiate(
                 deps.as_mut(),
                 mock_env(),
@@ -667,7 +668,7 @@ mod tests {
     fn proper_insert_blank_nodes() {
         let mut deps = mock_dependencies();
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         instantiate(
             deps.as_mut(),
             mock_env(),
@@ -701,7 +702,7 @@ mod tests {
     fn insert_existing_triples() {
         let mut deps = mock_dependencies();
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         instantiate(
             deps.as_mut(),
             mock_env(),
@@ -763,7 +764,7 @@ mod tests {
         instantiate(
             deps.as_mut(),
             mock_env(),
-            mock_info("owner", &[]),
+            message_info(&addr(OWNER), &[]),
             InstantiateMsg::default(),
         )
         .unwrap();
@@ -771,7 +772,7 @@ mod tests {
         let res = execute(
             deps.as_mut(),
             mock_env(),
-            mock_info("not-owner", &[]),
+            message_info(&addr("not-owner"), &[]),
             InsertData {
                 format: Some(DataFormat::RDFXml),
                 data: read_test_data("sample.rdf.xml"),
@@ -870,7 +871,7 @@ mod tests {
         for case in cases {
             let mut deps = mock_dependencies();
 
-            let info = mock_info("owner", &[]);
+            let info = message_info(&addr(OWNER), &[]);
             instantiate(
                 deps.as_mut(),
                 mock_env(),
@@ -1086,7 +1087,7 @@ mod tests {
         for case in cases {
             let mut deps = mock_dependencies();
 
-            let info = mock_info("owner", &[]);
+            let info = message_info(&addr(OWNER), &[]);
             instantiate(
                 deps.as_mut(),
                 mock_env(),
@@ -1196,7 +1197,7 @@ mod tests {
         for case in cases {
             let mut deps = mock_dependencies();
 
-            let info = mock_info("owner", &[]);
+            let info = message_info(&addr(OWNER), &[]);
             instantiate(
                 deps.as_mut(),
                 mock_env(),
@@ -1230,7 +1231,7 @@ mod tests {
             .save(
                 deps.as_mut().storage,
                 &Store {
-                    owner: Addr::unchecked("owner"),
+                    owner: Addr::unchecked(OWNER),
                     limits: StoreLimits {
                         max_triple_count: 1u128.into(),
                         max_byte_size: 2u128.into(),
@@ -1254,7 +1255,7 @@ mod tests {
         assert_eq!(
             from_json::<StoreResponse>(&res.unwrap()).unwrap(),
             StoreResponse {
-                owner: "owner".to_string(),
+                owner: OWNER.to_string(),
                 limits: msg::StoreLimits {
                     max_triple_count: 1u128.into(),
                     max_byte_size: 2u128.into(),
@@ -1455,7 +1456,7 @@ mod tests {
 
         let mut deps = mock_dependencies();
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         instantiate(
             deps.as_mut(),
             mock_env(),
@@ -1676,7 +1677,7 @@ mod tests {
 
         let mut deps = mock_dependencies();
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         instantiate(
             deps.as_mut(),
             mock_env(),
@@ -1776,7 +1777,7 @@ mod tests {
 
         let mut deps = mock_dependencies();
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         instantiate(
             deps.as_mut(),
             mock_env(),
@@ -1928,7 +1929,7 @@ mod tests {
 
         let mut deps = mock_dependencies();
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         instantiate(
             deps.as_mut(),
             mock_env(),
@@ -1998,7 +1999,7 @@ mod tests {
 
         let mut deps = mock_dependencies();
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         instantiate(
             deps.as_mut(),
             mock_env(),
@@ -2063,7 +2064,7 @@ mod tests {
 
         let mut deps = mock_dependencies();
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         instantiate(
             deps.as_mut(),
             mock_env(),
@@ -2128,7 +2129,7 @@ mod tests {
 
         let mut deps = mock_dependencies();
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         instantiate(
             deps.as_mut(),
             mock_env(),
@@ -2197,7 +2198,7 @@ mod tests {
 
         let mut deps = mock_dependencies();
 
-        let info = mock_info("owner", &[]);
+        let info = message_info(&addr(OWNER), &[]);
         instantiate(
             deps.as_mut(),
             mock_env(),
@@ -2374,7 +2375,7 @@ mod tests {
         for (data, q, expected) in cases {
             let mut deps = mock_dependencies();
 
-            let info = mock_info("owner", &[]);
+            let info = message_info(&addr(OWNER), &[]);
             instantiate(
                 deps.as_mut(),
                 mock_env(),

--- a/contracts/axone-cognitarium/src/state/blank_nodes.rs
+++ b/contracts/axone-cognitarium/src/state/blank_nodes.rs
@@ -1,4 +1,4 @@
 use cw_storage_plus::Item;
 
 /// A counter serving as blank node unique identifier generator.
-pub const BLANK_NODE_IDENTIFIER_COUNTER: Item<'_, u128> = Item::new("blank_node_key");
+pub const BLANK_NODE_IDENTIFIER_COUNTER: Item<u128> = Item::new("blank_node_key");

--- a/contracts/axone-cognitarium/src/state/namespaces.rs
+++ b/contracts/axone-cognitarium/src/state/namespaces.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 /// Store a key increment used a unique key for referencing a namespace. Given the size of an `u128`
 /// there is no need to implement a garbage collector mechanism in case some namespaces are removed.
-pub const NAMESPACE_KEY_INCREMENT: Item<'_, u128> = Item::new("namespace_key");
+pub const NAMESPACE_KEY_INCREMENT: Item<u128> = Item::new("namespace_key");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Namespace {
@@ -32,7 +32,7 @@ impl IndexList<Namespace> for NamespaceIndexes<'_> {
     }
 }
 
-pub fn namespaces<'a>() -> IndexedMap<'a, String, Namespace, NamespaceIndexes<'a>> {
+pub fn namespaces<'a>() -> IndexedMap<String, Namespace, NamespaceIndexes<'a>> {
     IndexedMap::new(
         "NAMESPACE",
         NamespaceIndexes {

--- a/contracts/axone-cognitarium/src/state/store.rs
+++ b/contracts/axone-cognitarium/src/state/store.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::Item;
 use serde::{Deserialize, Serialize};
 
-pub const STORE: Item<'_, Store> = Item::new("store");
+pub const STORE: Item<Store> = Item::new("store");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Store {

--- a/contracts/axone-cognitarium/src/state/triples.rs
+++ b/contracts/axone-cognitarium/src/state/triples.rs
@@ -20,7 +20,7 @@ impl IndexList<Triple> for TripleIndexes<'_> {
     }
 }
 
-pub fn triples<'a>() -> IndexedMap<'a, TriplePK<'a>, Triple, TripleIndexes<'a>> {
+pub fn triples<'a>() -> IndexedMap<TriplePK<'a>, Triple, TripleIndexes<'a>> {
     IndexedMap::new(
         "TRIPLE",
         TripleIndexes {

--- a/contracts/axone-cognitarium/tests/e2e/main.rs
+++ b/contracts/axone-cognitarium/tests/e2e/main.rs
@@ -3,7 +3,7 @@ use axone_cognitarium::ContractError;
 use base64::engine::general_purpose;
 use base64::Engine;
 use cosmwasm_std::testing::{
-    mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
+    message_info, mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
 };
 use cosmwasm_std::{MessageInfo, OwnedDeps, Response};
 use cucumber::parser::{Basic, Error};
@@ -13,6 +13,7 @@ use serde_yaml::Value;
 use std::fmt::Debug;
 use std::path::Path;
 use std::vec;
+use testing::addr::addr;
 
 #[derive(World)]
 #[world(init = Self::new)]
@@ -26,7 +27,7 @@ impl SmartContractWorld {
     fn new() -> Self {
         SmartContractWorld {
             deps: mock_dependencies(),
-            info: mock_info("owner", &[]),
+            info: message_info(&addr("owner"), &[]),
             response: Ok(Response::new()),
         }
     }

--- a/contracts/axone-cognitarium/tests/e2e/main.rs
+++ b/contracts/axone-cognitarium/tests/e2e/main.rs
@@ -3,7 +3,7 @@ use axone_cognitarium::ContractError;
 use base64::engine::general_purpose;
 use base64::Engine;
 use cosmwasm_std::testing::{
-    message_info, mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
+    message_info, mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage,
 };
 use cosmwasm_std::{MessageInfo, OwnedDeps, Response};
 use cucumber::parser::{Basic, Error};

--- a/contracts/axone-dataverse/Cargo.toml
+++ b/contracts/axone-dataverse/Cargo.toml
@@ -41,6 +41,7 @@ unsigned-varint = "0.8.0"
 [dev-dependencies]
 base64 = "0.22.1"
 cw-multi-test.workspace = true
+testing.workspace = true
 url = "2.5.2"
 
 [features]

--- a/contracts/axone-dataverse/Cargo.toml
+++ b/contracts/axone-dataverse/Cargo.toml
@@ -44,7 +44,5 @@ cw-multi-test.workspace = true
 url = "2.5.2"
 
 [features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []

--- a/contracts/axone-dataverse/src/contract.rs
+++ b/contracts/axone-dataverse/src/contract.rs
@@ -147,9 +147,7 @@ mod tests {
         SimpleWhereCondition, TriplePattern, Value, VarOrNamedNode, VarOrNode, VarOrNodeOrLiteral,
         WhereCondition, IRI,
     };
-    use cosmwasm_std::testing::{
-        message_info, mock_dependencies, mock_env, MockApi, MOCK_CONTRACT_ADDR,
-    };
+    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
     use cosmwasm_std::{
         coins, from_json, Addr, Attribute, Checksum, ContractResult, CosmosMsg, SubMsg,
         SystemError, SystemResult, Uint128, Uint64, WasmQuery,

--- a/contracts/axone-dataverse/src/contract.rs
+++ b/contracts/axone-dataverse/src/contract.rs
@@ -31,7 +31,7 @@ pub fn instantiate(
         .query_wasm_code_info(msg.triplestore_config.code_id.u64())?;
     let salt = Binary::from(msg.name.as_bytes());
 
-    let _triplestore_address = instantiate2_address(&checksum.as_slice(), &creator, &salt)?;
+    let _triplestore_address = instantiate2_address(checksum.as_slice(), &creator, &salt)?;
 
     // Necessary stuff for testing purposes, see: https://github.com/CosmWasm/cosmwasm/issues/1648
     let triplestore_address = {
@@ -147,8 +147,13 @@ mod tests {
         SimpleWhereCondition, TriplePattern, Value, VarOrNamedNode, VarOrNode, VarOrNodeOrLiteral,
         WhereCondition, IRI,
     };
-    use cosmwasm_std::testing::{message_info, MOCK_CONTRACT_ADDR, mock_dependencies, mock_env, MockApi};
-    use cosmwasm_std::{coins, from_json, Addr, Attribute, ContractResult, CosmosMsg, HexBinary, SubMsg, SystemError, SystemResult, Uint128, Uint64, WasmQuery, Checksum, BlockInfo, Timestamp, TransactionInfo, ContractInfo, OwnedDeps};
+    use cosmwasm_std::testing::{
+        message_info, mock_dependencies, mock_env, MockApi, MOCK_CONTRACT_ADDR,
+    };
+    use cosmwasm_std::{
+        coins, from_json, Addr, Attribute, Checksum, ContractResult, CosmosMsg, SubMsg,
+        SystemError, SystemResult, Uint128, Uint64, WasmQuery,
+    };
     use cw_utils::PaymentError::NonPayable;
     use std::collections::BTreeMap;
 
@@ -172,7 +177,10 @@ mod tests {
                 let resp = CodeInfoResponse::new(
                     code_id.clone(),
                     addr(CREATOR),
-                    Checksum::from_hex("3B94AAF0B7D804B5B458DED0D20CACF95D2A1C8DF78ED3C89B61291760454AEC").unwrap(),
+                    Checksum::from_hex(
+                        "3B94AAF0B7D804B5B458DED0D20CACF95D2A1C8DF78ED3C89B61291760454AEC",
+                    )
+                    .unwrap(),
                 );
                 SystemResult::Ok(ContractResult::Ok(to_json_binary(&resp).unwrap()))
             }
@@ -277,7 +285,7 @@ mod tests {
     fn execute_fail_with_funds() {
         let mut deps = mock_dependencies();
         let env = mock_env();
-        let info = mock_info("sender", &coins(10, "uaxone"));
+        let info = message_info(&addr("sender"), &coins(10, "uaxone"));
 
         let msg = ExecuteMsg::SubmitClaims {
             metadata: Binary::from("data".as_bytes()),
@@ -345,7 +353,10 @@ mod tests {
         let resp = execute(
             deps.as_mut(),
             mock_env(),
-            mock_info("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0", &[]),
+            message_info(
+                &Addr::unchecked("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0"),
+                &[],
+            ),
             ExecuteMsg::SubmitClaims {
                 metadata: Binary::new(read_test_data("vc-eddsa-2020-ok.nq")),
                 format: Some(RdfDatasetFormat::NQuads),
@@ -407,7 +418,10 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/exam
         let resp = execute(
             mock_dependencies().as_mut(),
             mock_env(),
-            mock_info("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0", &[]),
+            message_info(
+                &Addr::unchecked("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0"),
+                &[],
+            ),
             ExecuteMsg::SubmitClaims {
                 metadata: Binary::new("notrdf".as_bytes().to_vec()),
                 format: Some(RdfDatasetFormat::NQuads),
@@ -423,7 +437,10 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/exam
         let resp = execute(
             mock_dependencies().as_mut(),
             mock_env(),
-            mock_info("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0", &[]),
+            message_info(
+                &Addr::unchecked("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0"),
+                &[],
+            ),
             ExecuteMsg::SubmitClaims {
                 metadata: Binary::new(vec![]),
                 format: Some(RdfDatasetFormat::NQuads),
@@ -442,7 +459,10 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/exam
         let resp = execute(
             mock_dependencies().as_mut(),
             mock_env(),
-            mock_info("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0", &[]),
+            message_info(
+                &Addr::unchecked("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0"),
+                &[],
+            ),
             ExecuteMsg::SubmitClaims {
                 metadata: Binary::new(read_test_data("vc-eddsa-2020-ok-unsecured.nq")),
                 format: Some(RdfDatasetFormat::NQuads),
@@ -461,7 +481,10 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/exam
         let resp = execute(
             mock_dependencies().as_mut(),
             mock_env(),
-            mock_info("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0", &[]),
+            message_info(
+                &Addr::unchecked("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0"),
+                &[],
+            ),
             ExecuteMsg::SubmitClaims {
                 metadata: Binary::new(read_test_data("vc-unsupported-1.nq")),
                 format: Some(RdfDatasetFormat::NQuads),
@@ -509,7 +532,10 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/exam
         let resp = execute(
             deps.as_mut(),
             mock_env(),
-            mock_info("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0", &[]),
+            message_info(
+                &Addr::unchecked("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0"),
+                &[],
+            ),
             ExecuteMsg::SubmitClaims {
                 metadata: Binary::new(read_test_data("vc-eddsa-2020-ok.nq")),
                 format: Some(RdfDatasetFormat::NQuads),

--- a/contracts/axone-dataverse/src/contract.rs
+++ b/contracts/axone-dataverse/src/contract.rs
@@ -156,18 +156,8 @@ mod tests {
     };
     use cw_utils::PaymentError::NonPayable;
     use std::collections::BTreeMap;
-
-    const CREATOR: &str = "creator";
-
-    fn addr(input: &str) -> Addr {
-        MockApi::default().addr_make(input)
-    }
-
-    fn mock_env_addr() -> Env {
-        let mut env = mock_env();
-        env.contract.address = addr(MOCK_CONTRACT_ADDR);
-        env
-    }
+    use testing::addr::{addr, CREATOR, SENDER};
+    use testing::mock::mock_env_addr;
 
     #[test]
     fn proper_instantiate() {
@@ -201,8 +191,7 @@ mod tests {
         };
 
         let env = mock_env_addr();
-        let creator = deps.api.addr_make(CREATOR);
-        let info = message_info(&creator, &[]);
+        let info = message_info(&addr(CREATOR), &[]);
         let res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
 
         assert_eq!(
@@ -236,7 +225,7 @@ mod tests {
     fn funds_initialization() {
         let mut deps = mock_dependencies();
         let env = mock_env();
-        let info = message_info(&addr("sender"), &coins(10, "uaxone"));
+        let info = message_info(&addr(SENDER), &coins(10, "uaxone"));
 
         let msg = InstantiateMsg {
             name: "my-dataverse".to_string(),
@@ -285,7 +274,7 @@ mod tests {
     fn execute_fail_with_funds() {
         let mut deps = mock_dependencies();
         let env = mock_env();
-        let info = message_info(&addr("sender"), &coins(10, "uaxone"));
+        let info = message_info(&addr(SENDER), &coins(10, "uaxone"));
 
         let msg = ExecuteMsg::SubmitClaims {
             metadata: Binary::from("data".as_bytes()),

--- a/contracts/axone-dataverse/src/contract.rs
+++ b/contracts/axone-dataverse/src/contract.rs
@@ -31,7 +31,7 @@ pub fn instantiate(
         .query_wasm_code_info(msg.triplestore_config.code_id.u64())?;
     let salt = Binary::from(msg.name.as_bytes());
 
-    let _triplestore_address = instantiate2_address(&checksum, &creator, &salt)?;
+    let _triplestore_address = instantiate2_address(&checksum.as_slice(), &creator, &salt)?;
 
     // Necessary stuff for testing purposes, see: https://github.com/CosmWasm/cosmwasm/issues/1648
     let triplestore_address = {

--- a/contracts/axone-dataverse/src/registrar/rdf.rs
+++ b/contracts/axone-dataverse/src/registrar/rdf.rs
@@ -268,7 +268,7 @@ _:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/de
         assert!(serialization_res.is_ok());
 
         assert_eq!(
-            String::from_utf8(serialization_res.unwrap().0).unwrap(),
+            String::from_utf8(serialization_res.unwrap().to_vec()).unwrap(),
             expected
         );
     }
@@ -301,7 +301,7 @@ _:a0 <dataverse:claim#original-node> <test:named-link> .
         assert!(serialization_res.is_ok());
 
         assert_eq!(
-            String::from_utf8(serialization_res.unwrap().0).unwrap(),
+            String::from_utf8(serialization_res.unwrap().to_vec()).unwrap(),
             expected
         );
     }

--- a/contracts/axone-dataverse/src/state.rs
+++ b/contracts/axone-dataverse/src/state.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::Addr;
 use cw_storage_plus::Item;
 use serde::{Deserialize, Serialize};
 
-pub const DATAVERSE: Item<'_, Dataverse> = Item::new("dataverse");
+pub const DATAVERSE: Item<Dataverse> = Item::new("dataverse");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Dataverse {

--- a/contracts/axone-law-stone/Cargo.toml
+++ b/contracts/axone-law-stone/Cargo.toml
@@ -34,6 +34,7 @@ thiserror.workspace = true
 
 [dev-dependencies]
 cw-multi-test.workspace = true
+testing.workspace = true
 url = "2.5.2"
 
 [features]

--- a/contracts/axone-law-stone/Cargo.toml
+++ b/contracts/axone-law-stone/Cargo.toml
@@ -37,7 +37,5 @@ cw-multi-test.workspace = true
 url = "2.5.2"
 
 [features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []

--- a/contracts/axone-law-stone/src/contract.rs
+++ b/contracts/axone-law-stone/src/contract.rs
@@ -1065,11 +1065,10 @@ mod tests {
 
         for case in cases {
             let mut deps = mock_dependencies();
-            let creator = deps.api.addr_make(case.0);
             deps.querier.update_wasm(move |req| match req {
                 WasmQuery::ContractInfo { .. } => {
                     let contract_info =
-                        ContractInfoResponse::new(0, creator.clone(), None, false, None);
+                        ContractInfoResponse::new(0, addr(case.0), None, false, None);
 
                     SystemResult::Ok(ContractResult::Ok(to_json_binary(&contract_info).unwrap()))
                 }

--- a/contracts/axone-law-stone/src/contract.rs
+++ b/contracts/axone-law-stone/src/contract.rs
@@ -285,13 +285,12 @@ mod tests {
     use axone_objectarium::msg::PageInfo;
     use axone_wasm::uri::CosmwasmUri;
     use cosmwasm_std::testing::{
-        message_info, mock_dependencies, mock_env, mock_info, MockApi, MockQuerier,
+        message_info, mock_dependencies, mock_env, MockApi, MockQuerier,
         MockQuerierCustomHandlerResult, MockStorage,
     };
     use cosmwasm_std::{
-        coins, from_json, to_json_binary, Api, ContractInfoResponse, ContractResult, CosmosMsg,
-        Event, Order, OwnedDeps, SubMsgResponse, SubMsgResult, SystemError, SystemResult,
-        WasmQuery,
+        coins, from_json, to_json_binary, ContractInfoResponse, ContractResult, CosmosMsg, Event,
+        Order, OwnedDeps, SubMsgResponse, SubMsgResult, SystemError, SystemResult, WasmQuery,
     };
     use cw_utils::ParseReplyError::SubMsgFailure;
     use cw_utils::PaymentError;

--- a/contracts/axone-law-stone/src/state.rs
+++ b/contracts/axone-law-stone/src/state.rs
@@ -5,7 +5,7 @@ use axone_objectarium_client::ObjectRef;
 use cw_storage_plus::{Item, Map};
 
 /// State to store context during contract instantiation
-pub const INSTANTIATE_CONTEXT: Item<'_, String> = Item::new("instantiate");
+pub const INSTANTIATE_CONTEXT: Item<String> = Item::new("instantiate");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct LawStone {
@@ -22,6 +22,6 @@ impl From<LawStone> for ProgramResponse {
     }
 }
 
-pub const PROGRAM: Item<'_, LawStone> = Item::new("program");
+pub const PROGRAM: Item<LawStone> = Item::new("program");
 
-pub const DEPENDENCIES: Map<'_, &str, ObjectRef> = Map::new("dependencies");
+pub const DEPENDENCIES: Map<&str, ObjectRef> = Map::new("dependencies");

--- a/contracts/axone-objectarium/Cargo.toml
+++ b/contracts/axone-objectarium/Cargo.toml
@@ -39,6 +39,7 @@ thiserror.workspace = true
 [dev-dependencies]
 base64 = "0.22.1"
 cw-multi-test.workspace = true
+testing.workspace = true
 
 [features]
 # use library feature to disable all instantiate/execute/query exports

--- a/contracts/axone-objectarium/Cargo.toml
+++ b/contracts/axone-objectarium/Cargo.toml
@@ -41,7 +41,5 @@ base64 = "0.22.1"
 cw-multi-test.workspace = true
 
 [features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []

--- a/contracts/axone-objectarium/src/contract.rs
+++ b/contracts/axone-objectarium/src/contract.rs
@@ -119,7 +119,7 @@ pub mod execute {
         }
 
         // store object data
-        let id = crypto::hash(&bucket.config.hash_algorithm.into(), &data.0);
+        let id = crypto::hash(&bucket.config.hash_algorithm.into(), &data.to_vec());
         let mut res = Response::new()
             .add_attribute("action", "store_object")
             .add_attribute("id", id.to_string());
@@ -127,7 +127,7 @@ pub mod execute {
         let data_path = DATA.key(id.clone());
 
         let (old_obj, mut new_obj) = if !data_path.has(deps.storage) {
-            let compressed_data = compression.compress(&data.0)?;
+            let compressed_data = compression.compress(&data.to_vec())?;
             data_path.save(deps.storage, &compressed_data)?;
 
             let compressed_size = (compressed_data.len() as u128).into();

--- a/contracts/axone-objectarium/src/contract.rs
+++ b/contracts/axone-objectarium/src/contract.rs
@@ -127,7 +127,7 @@ pub mod execute {
         let data_path = DATA.key(id.clone());
 
         let (old_obj, mut new_obj) = if !data_path.has(deps.storage) {
-            let compressed_data = compression.compress(&data.to_vec())?;
+            let compressed_data = compression.compress(&data)?;
             data_path.save(deps.storage, &compressed_data)?;
 
             let compressed_size = (compressed_data.len() as u128).into();
@@ -443,13 +443,15 @@ mod tests {
         ObjectsResponse, PageInfo, PaginationConfigBuilder,
     };
     use base64::{engine::general_purpose, Engine as _};
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
     use cosmwasm_std::StdError::NotFound;
     use cosmwasm_std::{coins, from_json, Addr, Attribute, Order, StdError, Uint128};
     use cw_utils::PaymentError;
 
     use crate::msg::CompressionAlgorithm::{Passthrough, Snappy};
     use std::any::type_name;
+    use testing::addr::{addr, CREATOR, SENDER};
+    use testing::mock::mock_env_addr;
 
     fn decode_hex(hex: &str) -> Vec<u8> {
         base16ct::lower::decode_vec(hex).unwrap()
@@ -479,7 +481,7 @@ mod tests {
             limits: Default::default(),
             pagination: Default::default(),
         };
-        let info = mock_info("creator", &[]);
+        let info = message_info(&addr(CREATOR), &[]);
 
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(0, res.messages.len());
@@ -494,7 +496,7 @@ mod tests {
 
         // check internal state too
         let bucket = BUCKET.load(&deps.storage).unwrap();
-        assert_eq!("creator", bucket.owner.into_string());
+        assert_eq!(addr(CREATOR), bucket.owner);
         assert_eq!(Uint128::zero(), bucket.stat.size);
         assert_eq!(Uint128::zero(), bucket.stat.object_count);
     }
@@ -522,7 +524,7 @@ mod tests {
                 limits: Default::default(),
                 pagination: Default::default(),
             };
-            let info = mock_info("creator", &[]);
+            let info = message_info(&addr(CREATOR), &[]);
 
             let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
@@ -554,7 +556,7 @@ mod tests {
                 .build()
                 .unwrap(),
         };
-        let info = mock_info("creator", &[]);
+        let info = message_info(&addr(CREATOR), &[]);
         let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
         let res = query(deps.as_ref(), mock_env(), QueryMsg::Bucket {}).unwrap();
@@ -594,7 +596,13 @@ mod tests {
                 .build()
                 .unwrap(),
         };
-        instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
+        instantiate(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&addr(CREATOR), &[]),
+            msg,
+        )
+        .unwrap();
 
         let res = query(deps.as_ref(), mock_env(), QueryMsg::Bucket {}).unwrap();
         let value: BucketResponse = from_json(&res).unwrap();
@@ -742,7 +750,12 @@ mod tests {
                 limits: case.1,
                 pagination: case.2,
             };
-            match instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg) {
+            match instantiate(
+                deps.as_mut(),
+                mock_env(),
+                message_info(&addr(CREATOR), &[]),
+                msg,
+            ) {
                 Err(err) => {
                     assert!(case.3.is_some());
                     assert_eq!(err, ContractError::Std(case.3.unwrap()))
@@ -762,7 +775,7 @@ mod tests {
             limits: Default::default(),
             pagination: Default::default(),
         };
-        let info = mock_info("creator", &[]);
+        let info = message_info(&addr(CREATOR), &[]);
 
         let err = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap_err();
 
@@ -779,7 +792,7 @@ mod tests {
             limits: Default::default(),
             pagination: Default::default(),
         };
-        let info = mock_info("creator", &[]);
+        let info = message_info(&addr(CREATOR), &[]);
 
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(0, res.messages.len());
@@ -798,7 +811,7 @@ mod tests {
             limits: Default::default(),
             pagination: Default::default(),
         };
-        let info = mock_info("creator", &coins(10, "uaxone"));
+        let info = message_info(&addr(CREATOR), &coins(10, "uaxone"));
 
         let res = instantiate(deps.as_mut(), mock_env(), info, msg);
         assert!(res.is_err());
@@ -812,7 +825,7 @@ mod tests {
     fn execute_fail_with_funds() {
         let mut deps = mock_dependencies();
         let env = mock_env();
-        let info = mock_info("sender", &coins(10, "uaxone"));
+        let info = message_info(&addr(SENDER), &coins(10, "uaxone"));
 
         let messages = vec![
             ExecuteMsg::StoreObject {
@@ -1026,7 +1039,7 @@ mod tests {
 
         for (hash_algorithm, objs) in test_cases {
             let mut deps = mock_dependencies();
-            let info = mock_info("creator", &[]);
+            let info = message_info(&addr(CREATOR), &[]);
 
             instantiate(
                 deps.as_mut(),
@@ -1112,7 +1125,7 @@ mod tests {
     #[test]
     fn store_object_already_stored() {
         let mut deps = mock_dependencies();
-        let info = mock_info("creator", &[]);
+        let info = message_info(&addr(CREATOR), &[]);
         let msg = InstantiateMsg {
             bucket: String::from("test"),
             config: Default::default(),
@@ -1242,7 +1255,7 @@ mod tests {
 
         for case in cases {
             let mut deps = mock_dependencies();
-            let info = mock_info("creator", &[]);
+            let info = message_info(&addr(CREATOR), &[]);
             let msg = InstantiateMsg {
                 bucket: String::from("test"),
                 config: Default::default(),
@@ -1362,7 +1375,7 @@ mod tests {
         for case in cases {
             // Arrange
             let mut deps = mock_dependencies();
-            let info = mock_info("creator", &[]);
+            let info = message_info(&addr(CREATOR), &[]);
             let msg = InstantiateMsg {
                 bucket: String::from("test"),
                 config: BucketConfig {
@@ -1398,7 +1411,7 @@ mod tests {
                         res_object_info,
                         ObjectResponse {
                             id: obj_id.to_string(),
-                            owner: "creator".to_string(),
+                            owner: addr(CREATOR).to_string(),
                             is_pinned: false,
                             size: Uint128::from(data.len() as u128),
                             compressed_size: expected.compressed_size.into(),
@@ -1527,7 +1540,7 @@ mod tests {
 
         for (content, pin, compression_algorithm, expected_attr) in &test_cases {
             let mut deps = mock_dependencies();
-            let info = mock_info("creator", &[]);
+            let info = message_info(&addr(CREATOR), &[]);
             let msg = InstantiateMsg {
                 bucket: String::from("test"),
                 config: Default::default(),
@@ -1572,7 +1585,7 @@ mod tests {
     #[test]
     fn object() {
         let mut deps = mock_dependencies();
-        let info = mock_info("creator", &[]);
+        let info = message_info(&addr(CREATOR), &[]);
 
         let msg = InstantiateMsg {
             bucket: String::from("test"),
@@ -1659,7 +1672,7 @@ mod tests {
 
         for case in cases {
             let mut deps = mock_dependencies();
-            let info = mock_info("creator", &[]);
+            let info = message_info(&addr(CREATOR), &[]);
             let data =
                 Binary::from_base64(general_purpose::STANDARD.encode("okp4").as_str()).unwrap();
 
@@ -1752,7 +1765,7 @@ mod tests {
                 objects: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                senders: vec![mock_info("bob", &[])],
+                senders: vec![message_info(&addr("bob"), &[])],
                 expected_count: 1,
                 expected_error: None,
                 expected_object_pin_count: vec![(
@@ -1772,7 +1785,10 @@ mod tests {
                         "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                     ),
                 ],
-                senders: vec![mock_info("bob", &[]), mock_info("alice", &[])],
+                senders: vec![
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("alice"), &[]),
+                ],
                 expected_count: 2,
                 expected_error: None,
                 expected_object_pin_count: vec![(
@@ -1792,7 +1808,10 @@ mod tests {
                         "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                     ),
                 ],
-                senders: vec![mock_info("bob", &[]), mock_info("bob", &[])],
+                senders: vec![
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("bob"), &[]),
+                ],
                 expected_count: 1,
                 expected_error: None,
                 expected_object_pin_count: vec![(
@@ -1812,7 +1831,10 @@ mod tests {
                         "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
                     ),
                 ],
-                senders: vec![mock_info("bob", &[]), mock_info("bob", &[])],
+                senders: vec![
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("bob"), &[]),
+                ],
                 expected_count: 2,
                 expected_error: None,
                 expected_object_pin_count: vec![
@@ -1840,7 +1862,10 @@ mod tests {
                         "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
                     ),
                 ],
-                senders: vec![mock_info("bob", &[]), mock_info("alice", &[])],
+                senders: vec![
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("alice"), &[]),
+                ],
                 expected_count: 2,
                 expected_error: None,
                 expected_object_pin_count: vec![
@@ -1872,9 +1897,9 @@ mod tests {
                     ),
                 ],
                 senders: vec![
-                    mock_info("bob", &[]),
-                    mock_info("alice", &[]),
-                    mock_info("alice", &[]),
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("alice"), &[]),
+                    message_info(&addr("alice"), &[]),
                 ],
                 expected_count: 2,
                 expected_error: None,
@@ -1910,10 +1935,10 @@ mod tests {
                     ),
                 ],
                 senders: vec![
-                    mock_info("bob", &[]),
-                    mock_info("alice", &[]),
-                    mock_info("martin", &[]),
-                    mock_info("pierre", &[]),
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("alice"), &[]),
+                    message_info(&addr("martin"), &[]),
+                    message_info(&addr("pierre"), &[]),
                 ],
                 expected_count: 3,
                 expected_error: Some(ContractError::Bucket(
@@ -1939,7 +1964,7 @@ mod tests {
                 objects: vec![ObjectId::from(
                     "abafa4428bdc8c34dae28bbc17303a62175f274edf59757b3e9898215a428a56",
                 )],
-                senders: vec![mock_info("bob", &[])],
+                senders: vec![message_info(&addr("bob"), &[])],
                 expected_count: 0,
                 expected_error: Some(ContractError::Std(StdError::not_found(
                     not_found_object_info::<Object>(
@@ -1956,7 +1981,7 @@ mod tests {
             TC {
                 // Invalid object id
                 objects: vec![ObjectId::from("invalid id")],
-                senders: vec![mock_info("bob", &[])],
+                senders: vec![message_info(&addr("bob"), &[])],
                 expected_count: 0,
                 expected_error: Some(ContractError::Std(StdError::parse_err(
                     type_name::<Vec<u8>>(),
@@ -1973,7 +1998,7 @@ mod tests {
 
         for case in cases {
             let mut deps = mock_dependencies();
-            let info = mock_info("creator", &[]);
+            let info = message_info(&addr(CREATOR), &[]);
 
             instantiate(
                 deps.as_mut(),
@@ -2070,11 +2095,11 @@ mod tests {
                 pin: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                pin_senders: vec![mock_info("bob", &[])],
+                pin_senders: vec![message_info(&addr("bob"), &[])],
                 unpin: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                unpin_senders: vec![mock_info("bob", &[])],
+                unpin_senders: vec![message_info(&addr("bob"), &[])],
                 expected_count: 0,
                 expected_error: None,
                 expected_object_pin_count: vec![(
@@ -2088,11 +2113,11 @@ mod tests {
                 pin: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                pin_senders: vec![mock_info("bob", &[])],
+                pin_senders: vec![message_info(&addr("bob"), &[])],
                 unpin: vec![ObjectId::from(
                     "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
                 )],
-                unpin_senders: vec![mock_info("bob", &[])],
+                unpin_senders: vec![message_info(&addr("bob"), &[])],
                 expected_count: 1,
                 expected_error: None,
                 expected_object_pin_count: vec![
@@ -2119,11 +2144,14 @@ mod tests {
                         "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
                     ),
                 ],
-                pin_senders: vec![mock_info("bob", &[]), mock_info("bob", &[])],
+                pin_senders: vec![
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("bob"), &[]),
+                ],
                 unpin: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                unpin_senders: vec![mock_info("bob", &[])],
+                unpin_senders: vec![message_info(&addr("bob"), &[])],
                 expected_count: 1,
                 expected_error: None,
                 expected_object_pin_count: vec![
@@ -2147,7 +2175,7 @@ mod tests {
                 unpin: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                unpin_senders: vec![mock_info("bob", &[])],
+                unpin_senders: vec![message_info(&addr("bob"), &[])],
                 expected_count: 0,
                 expected_error: None,
                 expected_object_pin_count: vec![(
@@ -2173,15 +2201,15 @@ mod tests {
                     ),
                 ],
                 pin_senders: vec![
-                    mock_info("bob", &[]),
-                    mock_info("alice", &[]),
-                    mock_info("martin", &[]),
-                    mock_info("pierre", &[]),
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("alice"), &[]),
+                    message_info(&addr("martin"), &[]),
+                    message_info(&addr("pierre"), &[]),
                 ],
                 unpin: vec![ObjectId::from(
                     "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
                 )],
-                unpin_senders: vec![mock_info("martin", &[])],
+                unpin_senders: vec![message_info(&addr("martin"), &[])],
                 expected_count: 3,
                 expected_error: None,
                 expected_object_pin_count: vec![
@@ -2204,11 +2232,11 @@ mod tests {
                 pin: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                pin_senders: vec![mock_info("bob", &[])],
+                pin_senders: vec![message_info(&addr("bob"), &[])],
                 unpin: vec![ObjectId::from(
                     "abafa4428bdc8c34dae28bbc17303a62175f274edf59757b3e9898215a428a56",
                 )],
-                unpin_senders: vec![mock_info("martin", &[])],
+                unpin_senders: vec![message_info(&addr("martin"), &[])],
                 expected_count: 1,
                 expected_error: Some(ContractError::Std(StdError::not_found(
                     not_found_object_info::<Object>(
@@ -2227,9 +2255,9 @@ mod tests {
                 pin: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                pin_senders: vec![mock_info("bob", &[])],
+                pin_senders: vec![message_info(&addr("bob"), &[])],
                 unpin: vec![ObjectId::from("invalid id")],
-                unpin_senders: vec![mock_info("martin", &[])],
+                unpin_senders: vec![message_info(&addr("martin"), &[])],
                 expected_count: 1,
                 expected_error: Some(ContractError::Std(StdError::parse_err(
                     type_name::<Vec<u8>>(),
@@ -2246,7 +2274,7 @@ mod tests {
 
         for case in cases {
             let mut deps = mock_dependencies();
-            let info = mock_info("creator", &[]);
+            let info = message_info(&addr(CREATOR), &[]);
 
             instantiate(
                 deps.as_mut(),
@@ -2339,8 +2367,8 @@ mod tests {
     #[test]
     fn fetch_objects() {
         let mut deps = mock_dependencies();
-        let info1 = mock_info("creator1", &[]);
-        let info2 = mock_info("creator2", &[]);
+        let info1 = message_info(&addr("creator1"), &[]);
+        let info2 = message_info(&addr("creator2"), &[]);
 
         let msg = InstantiateMsg {
             bucket: String::from("test"),
@@ -2403,7 +2431,7 @@ mod tests {
             ),
             (
                 QueryMsg::Objects {
-                    address: Some("unknown".to_string()),
+                    address: Some(addr("unknown").to_string()),
                     first: None,
                     after: None,
                 },
@@ -2415,7 +2443,7 @@ mod tests {
             ),
             (
                 QueryMsg::Objects {
-                    address: Some("creator1".to_string()),
+                    address: Some(addr("creator1").to_string()),
                     first: None,
                     after: None,
                 },
@@ -2427,7 +2455,7 @@ mod tests {
             ),
             (
                 QueryMsg::Objects {
-                    address: Some("creator1".to_string()),
+                    address: Some(addr("creator1").to_string()),
                     first: Some(1),
                     after: None,
                 },
@@ -2439,7 +2467,7 @@ mod tests {
             ),
             (
                 QueryMsg::Objects {
-                    address: Some("creator1".to_string()),
+                    address: Some(addr("creator1").to_string()),
                     first: Some(1),
                     after: Some("5bfWM6UF5MowkQVp16q5pnXvwc9SVkS4xZkFeVLdswjU".to_string()),
                 },
@@ -2460,7 +2488,7 @@ mod tests {
         }
 
         let msg = QueryMsg::Objects {
-            address: Some("creator2".to_string()),
+            address: Some(addr("creator2").to_string()),
             first: None,
             after: None,
         };
@@ -2470,7 +2498,7 @@ mod tests {
             response.data.first().unwrap(),
             &ObjectResponse {
                 id: "0a6d95579ba3dd2f79c870906fd894007ce449020d111d358894cfbbcd9a03a4".to_string(),
-                owner: "creator2".to_string(),
+                owner: addr("creator2").to_string(),
                 is_pinned: false,
                 size: 7u128.into(),
                 compressed_size: 7u128.into(),
@@ -2482,8 +2510,8 @@ mod tests {
     #[test]
     fn object_pins() {
         let mut deps = mock_dependencies();
-        let info1 = mock_info("creator1", &[]);
-        let info2 = mock_info("creator2", &[]);
+        let info1 = message_info(&addr("creator1"), &[]);
+        let info2 = message_info(&addr("creator2"), &[]);
 
         let msg = InstantiateMsg {
             bucket: String::from("test"),
@@ -2522,7 +2550,7 @@ mod tests {
                     first: None,
                     after: None,
                 },
-                Vec::<String>::new(),
+                Vec::<Addr>::new(),
                 PageInfo {
                     has_next_page: false,
                     cursor: "".to_string(),
@@ -2535,10 +2563,10 @@ mod tests {
                     first: None,
                     after: None,
                 },
-                vec!["creator1".to_string(), "creator2".to_string()],
+                vec![addr("creator2"), addr("creator1")],
                 PageInfo {
                     has_next_page: false,
-                    cursor: "Hdm2eF21ryF".to_string(),
+                    cursor: "3wwsaS9LwRtjTvYihWjb64ph5BdBrkTrt8f2sG6vBiE774tMxX31Rs9Mqn91NGQ6MzUow4Gi5iBR6STw68tuG2esLAdK".to_string(),
                 },
             ),
             (
@@ -2548,10 +2576,10 @@ mod tests {
                     first: Some(1),
                     after: None,
                 },
-                vec!["creator1".to_string()],
+                vec![addr("creator2")],
                 PageInfo {
                     has_next_page: true,
-                    cursor: "Hdm2eF21ryE".to_string(),
+                    cursor: "3wwsaS9LwRtjTrrGpg2qSGEo3gFkR53R2hUNX2PapfytooQuGcPiyF4zRneMECgJiZXS336Cd7pZU4CJ96nt3mcoQR8g".to_string(),
                 },
             ),
             (
@@ -2559,20 +2587,27 @@ mod tests {
                     id: "abafa4428bdc8c34dae28bbc17303a62175f274edf59757b3e9898215a428a56"
                         .to_string(),
                     first: Some(1),
-                    after: Some("Hdm2eF21ryE".to_string()),
+                    after: Some("3wwsaS9LwRtjTrrGpg2qSGEo3gFkR53R2hUNX2PapfytooQuGcPiyF4zRneMECgJiZXS336Cd7pZU4CJ96nt3mcoQR8g".to_string()),
                 },
-                vec!["creator2".to_string()],
+                vec![addr("creator1")],
                 PageInfo {
                     has_next_page: false,
-                    cursor: "Hdm2eF21ryF".to_string(),
+                    cursor: "3wwsaS9LwRtjTvYihWjb64ph5BdBrkTrt8f2sG6vBiE774tMxX31Rs9Mqn91NGQ6MzUow4Gi5iBR6STw68tuG2esLAdK".to_string(),
                 },
             ),
         ];
 
         for case in cases {
-            let result = query(deps.as_ref(), mock_env(), case.0).unwrap();
+            let result = query(deps.as_ref(), mock_env_addr(), case.0).unwrap();
             let response: ObjectPinsResponse = from_json(&result).unwrap();
-            assert_eq!(response.data, case.1);
+            assert_eq!(
+                response
+                    .data
+                    .iter()
+                    .map(|a| Addr::unchecked(a))
+                    .collect::<Vec<Addr>>(),
+                case.1
+            );
             assert_eq!(response.page_info, case.2);
         }
     }
@@ -2587,7 +2622,13 @@ mod tests {
             limits: Default::default(),
             pagination: Default::default(),
         };
-        instantiate(deps.as_mut(), mock_env(), mock_info("creator1", &[]), msg).unwrap();
+        instantiate(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&addr("creator1"), &[]),
+            msg,
+        )
+        .unwrap();
 
         let cases = vec![
             (
@@ -2640,7 +2681,7 @@ mod tests {
                 forget_objects: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                forget_senders: vec![mock_info("bob", &[])],
+                forget_senders: vec![message_info(&addr("bob"), &[])],
                 expected_count: 3,
                 expected_total_size: Uint128::new(474),
                 expected_compressed_size: Uint128::new(418),
@@ -2657,7 +2698,10 @@ mod tests {
                         "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
                     ),
                 ],
-                forget_senders: vec![mock_info("bob", &[]), mock_info("bob", &[])],
+                forget_senders: vec![
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("bob"), &[]),
+                ],
                 expected_count: 2,
                 expected_total_size: Uint128::new(469),
                 expected_compressed_size: Uint128::new(413),
@@ -2669,7 +2713,10 @@ mod tests {
                 forget_objects: vec![ObjectId::from(
                     "d1abcabb14dd23d2cf60472dffb4823be10ac20148e8ef7b9644cc14fcf8a073",
                 )],
-                forget_senders: vec![mock_info("bob", &[]), mock_info("bob", &[])],
+                forget_senders: vec![
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("bob"), &[]),
+                ],
                 expected_count: 3,
                 expected_total_size: Uint128::new(13),
                 expected_compressed_size: Uint128::new(13),
@@ -2679,11 +2726,11 @@ mod tests {
                 pins: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                pins_senders: vec![mock_info("bob", &[])],
+                pins_senders: vec![message_info(&addr("bob"), &[])],
                 forget_objects: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                forget_senders: vec![mock_info("alice", &[])], // the sender is different from the pinner, so error
+                forget_senders: vec![message_info(&addr("alice"), &[])], // the sender is different from the pinner, so error
                 expected_count: 4,
                 expected_total_size: Uint128::new(478),
                 expected_compressed_size: Uint128::new(422),
@@ -2693,11 +2740,11 @@ mod tests {
                 pins: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                pins_senders: vec![mock_info("bob", &[])],
+                pins_senders: vec![message_info(&addr("bob"), &[])],
                 forget_objects: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                forget_senders: vec![mock_info("bob", &[])], // the sender is the same as the pinner, so forget should work
+                forget_senders: vec![message_info(&addr("bob"), &[])], // the sender is the same as the pinner, so forget should work
                 expected_count: 3,
                 expected_total_size: Uint128::new(474),
                 expected_compressed_size: Uint128::new(418),
@@ -2712,11 +2759,14 @@ mod tests {
                         "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                     ),
                 ],
-                pins_senders: vec![mock_info("bob", &[]), mock_info("alice", &[])],
+                pins_senders: vec![
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("alice"), &[]),
+                ],
                 forget_objects: vec![ObjectId::from(
                     "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                 )],
-                forget_senders: vec![mock_info("bob", &[])], // the sender is the same as the pinner, but another pinner is on it so error
+                forget_senders: vec![message_info(&addr("bob"), &[])], // the sender is the same as the pinner, but another pinner is on it so error
                 expected_count: 4,
                 expected_total_size: Uint128::new(478),
                 expected_compressed_size: Uint128::new(422),
@@ -2731,11 +2781,14 @@ mod tests {
                         "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                     ),
                 ],
-                pins_senders: vec![mock_info("bob", &[]), mock_info("alice", &[])],
+                pins_senders: vec![
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("alice"), &[]),
+                ],
                 forget_objects: vec![ObjectId::from(
                     "abafa4428bdc8c34dae28bbc17303a62175f274edf59757b3e9898215a428a56",
                 )],
-                forget_senders: vec![mock_info("bob", &[])], // the sender is the same as the pinner, but another pinner is on it so error
+                forget_senders: vec![message_info(&addr("bob"), &[])], // the sender is the same as the pinner, but another pinner is on it so error
                 expected_count: 4,
                 expected_total_size: Uint128::new(478),
                 expected_compressed_size: Uint128::new(422),
@@ -2754,9 +2807,12 @@ mod tests {
                         "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
                     ),
                 ],
-                pins_senders: vec![mock_info("bob", &[]), mock_info("alice", &[])],
+                pins_senders: vec![
+                    message_info(&addr("bob"), &[]),
+                    message_info(&addr("alice"), &[]),
+                ],
                 forget_objects: vec![ObjectId::from("invalid id")],
-                forget_senders: vec![mock_info("bob", &[])], // the sender is the same as the pinner, but another pinner is on it so error
+                forget_senders: vec![message_info(&addr("bob"), &[])], // the sender is the same as the pinner, but another pinner is on it so error
                 expected_count: 4,
                 expected_total_size: Uint128::new(478),
                 expected_compressed_size: Uint128::new(422),
@@ -2769,7 +2825,7 @@ mod tests {
 
         for case in cases {
             let mut deps = mock_dependencies();
-            let info = mock_info("creator", &[]);
+            let info = message_info(&addr(CREATOR), &[]);
 
             instantiate(
                 deps.as_mut(),
@@ -2896,7 +2952,7 @@ mod tests {
     #[test]
     fn store_forgotten_object() {
         let mut deps = mock_dependencies();
-        let info = mock_info("creator", &[]);
+        let info = message_info(&addr(CREATOR), &[]);
 
         instantiate(
             deps.as_mut(),

--- a/contracts/axone-objectarium/src/contract.rs
+++ b/contracts/axone-objectarium/src/contract.rs
@@ -1613,7 +1613,7 @@ mod tests {
             response.id,
             ObjectId::from("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
         );
-        assert_eq!(response.owner, info.sender);
+        assert_eq!(response.owner, info.sender.as_str());
         assert!(response.is_pinned);
         assert_eq!(response.size.u128(), 5u128);
 
@@ -1634,7 +1634,7 @@ mod tests {
             response.id,
             ObjectId::from("315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6")
         );
-        assert_eq!(response.owner, info.sender);
+        assert_eq!(response.owner, info.sender.as_str());
         assert!(!response.is_pinned);
         assert_eq!(response.size.u128(), 4u128);
     }

--- a/contracts/axone-objectarium/src/crypto.rs
+++ b/contracts/axone-objectarium/src/crypto.rs
@@ -123,6 +123,7 @@ impl<'a> PrimaryKey<'a> for Hash {
 
 impl KeyDeserialize for Hash {
     type Output = Hash;
+    const KEY_ELEMS: u16 = 1;
 
     #[inline(always)]
     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
@@ -132,6 +133,7 @@ impl KeyDeserialize for Hash {
 
 impl KeyDeserialize for &Hash {
     type Output = Hash;
+    const KEY_ELEMS: u16 = 1;
 
     #[inline(always)]
     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {

--- a/contracts/axone-objectarium/src/state.rs
+++ b/contracts/axone-objectarium/src/state.rs
@@ -9,7 +9,7 @@ use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub const DATA: Map<'_, Hash, Vec<u8>> = Map::new("DATA");
+pub const DATA: Map<Hash, Vec<u8>> = Map::new("DATA");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Bucket {
@@ -322,7 +322,7 @@ impl TryFrom<PaginationConfig> for Pagination {
     }
 }
 
-pub const BUCKET: Item<'_, Bucket> = Item::new("bucket");
+pub const BUCKET: Item<Bucket> = Item::new("bucket");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Object {
@@ -364,7 +364,7 @@ impl IndexList<Object> for ObjectIndexes<'_> {
     }
 }
 
-pub fn objects<'a>() -> IndexedMap<'a, Hash, Object, ObjectIndexes<'a>> {
+pub fn objects<'a>() -> IndexedMap<Hash, Object, ObjectIndexes<'a>> {
     IndexedMap::new(
         "OBJECT",
         ObjectIndexes {
@@ -392,7 +392,7 @@ impl IndexList<Pin> for PinIndexes<'_> {
     }
 }
 
-pub fn pins<'a>() -> IndexedMap<'a, (Hash, Addr), Pin, PinIndexes<'a>> {
+pub fn pins<'a>() -> IndexedMap<(Hash, Addr), Pin, PinIndexes<'a>> {
     IndexedMap::new(
         "PIN",
         PinIndexes {

--- a/docs/axone-cognitarium.md
+++ b/docs/axone-cognitarium.md
@@ -876,4 +876,4 @@ Represents a condition in a [WhereClause].
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-cognitarium.json` (`d8d7e78708aa2e5c`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-cognitarium.json` (`8f8a0452855d9314`)_

--- a/docs/axone-law-stone.md
+++ b/docs/axone-law-stone.md
@@ -136,4 +136,4 @@ A string containing Base64-encoded data.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-law-stone.json` (`f8eb198b23eb9c74`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-law-stone.json` (`e30899a776e9d303`)_

--- a/packages/testing/Cargo.toml
+++ b/packages/testing/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
+authors = ["AXONE"]
 edition = "2021"
 name = "testing"
-version = "0.1.0"
+version = "5.0.0"
 
 [dependencies]
 cosmwasm-std.workspace = true

--- a/packages/testing/Cargo.toml
+++ b/packages/testing/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+edition = "2021"
+name = "testing"
+version = "0.1.0"
+
+[dependencies]
+cosmwasm-std.workspace = true

--- a/packages/testing/Makefile.toml
+++ b/packages/testing/Makefile.toml
@@ -1,0 +1,1 @@
+[tasks.schema]

--- a/packages/testing/src/addr.rs
+++ b/packages/testing/src/addr.rs
@@ -1,0 +1,9 @@
+use cosmwasm_std::testing::MockApi;
+use cosmwasm_std::Addr;
+
+pub const CREATOR: &str = "creator";
+pub const SENDER: &str = "sender";
+
+pub fn addr(input: &str) -> Addr {
+    MockApi::default().addr_make(input)
+}

--- a/packages/testing/src/addr.rs
+++ b/packages/testing/src/addr.rs
@@ -3,6 +3,7 @@ use cosmwasm_std::Addr;
 
 pub const CREATOR: &str = "creator";
 pub const SENDER: &str = "sender";
+pub const OWNER: &str = "owner";
 
 pub fn addr(input: &str) -> Addr {
     MockApi::default().addr_make(input)

--- a/packages/testing/src/lib.rs
+++ b/packages/testing/src/lib.rs
@@ -1,2 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 pub mod addr;
 pub mod mock;

--- a/packages/testing/src/lib.rs
+++ b/packages/testing/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod addr;
+pub mod mock;

--- a/packages/testing/src/mock.rs
+++ b/packages/testing/src/mock.rs
@@ -1,0 +1,9 @@
+use crate::addr::addr;
+use cosmwasm_std::testing::{mock_env, MOCK_CONTRACT_ADDR};
+use cosmwasm_std::Env;
+
+pub fn mock_env_addr() -> Env {
+    let mut env = mock_env();
+    env.contract.address = addr(MOCK_CONTRACT_ADDR);
+    env
+}


### PR DESCRIPTION
This PR updates CosmWasm to [v2.1.1](https://github.com/CosmWasm/cosmwasm/blob/v2.1.1/CHANGELOG.md) following the [migration guide](https://github.com/CosmWasm/cosmwasm/blob/v2.1.1/MIGRATING.md).

Additionally, a `testing` package has been added to provide common testing utility functions. Since CosmWasm 2.0.0 introduced a new API for mocking info and requires a valid address, this helper library has been created to avoid duplicating utility functions. It includes functions to generate valid addresses in the mocked environment, addressing the issue described in [CosmWasm issue #2157](https://github.com/CosmWasm/cosmwasm/issues/2157).