### PR TITLE
feat(cognitarium)!: add query expression filters

### DIFF
--- a/contracts/axone-cognitarium/src/contract.rs
+++ b/contracts/axone-cognitarium/src/contract.rs
@@ -244,7 +244,7 @@ pub mod query {
                 (
                     vec![select.clone()],
                     WhereClause::Bgp {
-                        patterns: vec![select.clone()],
+                        patterns: vec![select],
                     },
                 )
             }

--- a/contracts/axone-cognitarium/src/contract.rs
+++ b/contracts/axone-cognitarium/src/contract.rs
@@ -53,10 +53,8 @@ pub fn execute(
 
 pub mod execute {
     use super::*;
-    use crate::msg::{
-        DataFormat, Prefix, SimpleWhereCondition, TripleDeleteTemplate, WhereClause, WhereCondition,
-    };
-    use crate::querier::{PlanBuilder, QueryEngine, ResolvedVariables};
+    use crate::msg::{DataFormat, Prefix, TripleDeleteTemplate, WhereClause};
+    use crate::querier::{PlanBuilder, QueryEngine, QueryPlan, ResolvedVariables};
     use crate::rdf::PrefixMap;
     use crate::state::{HasCachedNamespaces, Triple};
     use crate::storer::StoreEngine;
@@ -95,21 +93,18 @@ pub mod execute {
         info: MessageInfo,
         prefixes: Vec<Prefix>,
         delete: Vec<TripleDeleteTemplate>,
-        r#where: WhereClause,
+        r#where: Option<WhereClause>,
     ) -> Result<Response, ContractError> {
         verify_owner(&deps, &info)?;
 
         let delete = if delete.is_empty() {
-            Left(
-                r#where
+            Left(match r#where {
+                Some(WhereClause::Bgp { ref patterns }) => patterns
                     .iter()
-                    .map(|c| match c {
-                        WhereCondition::Simple(SimpleWhereCondition::TriplePattern(t)) => {
-                            (t.subject.clone(), t.predicate.clone(), t.object.clone())
-                        }
-                    })
+                    .map(|p| (p.subject.clone(), p.predicate.clone(), p.object.clone()))
                     .collect(),
-            )
+                _ => Err(StdError::generic_err("Missing triple templates to delete"))?,
+            })
         } else {
             Right(
                 delete
@@ -121,7 +116,10 @@ pub mod execute {
 
         let prefix_map = <PrefixMap>::from(prefixes).into_inner();
         let mut plan_builder = PlanBuilder::new(deps.storage, &prefix_map, None);
-        let plan = plan_builder.build_plan(&r#where)?;
+        let plan = match r#where {
+            Some(ref w) => plan_builder.build_plan(w)?,
+            None => QueryPlan::empty_plan(),
+        };
 
         let query_engine = QueryEngine::new(deps.storage);
         let delete_templates = query_engine.make_triple_templates(
@@ -131,7 +129,7 @@ pub mod execute {
             plan_builder.cached_namespaces(),
         )?;
 
-        let triples = if r#where.is_empty() {
+        let triples = if r#where.is_none() {
             let empty_vars = ResolvedVariables::with_capacity(0);
             delete_templates
                 .into_iter()
@@ -176,8 +174,8 @@ pub mod query {
     use super::*;
     use crate::msg::{
         ConstructQuery, ConstructResponse, DescribeQuery, DescribeResponse, Node, SelectQuery,
-        SelectResponse, SimpleWhereCondition, StoreResponse, TripleConstructTemplate,
-        TriplePattern, VarOrNamedNode, VarOrNode, VarOrNodeOrLiteral, WhereCondition,
+        SelectResponse, StoreResponse, TripleConstructTemplate, TriplePattern, VarOrNamedNode,
+        VarOrNode, VarOrNodeOrLiteral, WhereClause,
     };
     use crate::querier::{PlanBuilder, QueryEngine};
     use crate::rdf::PrefixMap;
@@ -227,10 +225,17 @@ pub mod query {
                     object: VarOrNodeOrLiteral::Variable(format!("{var}{o}")),
                 };
 
-                let mut r#where = query.r#where;
-                r#where.push(WhereCondition::Simple(SimpleWhereCondition::TriplePattern(
-                    select.clone(),
-                )));
+                let r#where = match query.r#where {
+                    Some(c) => WhereClause::LateralJoin {
+                        left: Box::new(c),
+                        right: Box::new(WhereClause::Bgp {
+                            patterns: vec![select.clone()],
+                        }),
+                    },
+                    None => WhereClause::Bgp {
+                        patterns: vec![select.clone()],
+                    },
+                };
 
                 (vec![select], r#where)
             }
@@ -243,9 +248,9 @@ pub mod query {
 
                 (
                     vec![select.clone()],
-                    vec![WhereCondition::Simple(SimpleWhereCondition::TriplePattern(
-                        select,
-                    ))],
+                    WhereClause::Bgp {
+                        patterns: vec![select.clone()],
+                    },
                 )
             }
         };
@@ -279,18 +284,17 @@ pub mod query {
         } = query;
 
         let construct = if construct.is_empty() {
-            r#where
-                .iter()
-                .map(|t| match t {
-                    WhereCondition::Simple(SimpleWhereCondition::TriplePattern(t)) => {
-                        TripleConstructTemplate {
-                            subject: t.subject.clone(),
-                            predicate: t.predicate.clone(),
-                            object: t.object.clone(),
-                        }
-                    }
-                })
-                .collect()
+            match &r#where {
+                WhereClause::Bgp { patterns } => patterns
+                    .iter()
+                    .map(|p| TripleConstructTemplate {
+                        subject: p.subject.clone(),
+                        predicate: p.predicate.clone(),
+                        object: p.object.clone(),
+                    })
+                    .collect(),
+                _ => Err(StdError::generic_err("missing triples to construct"))?,
+            }
         } else {
             construct
         };
@@ -431,14 +435,14 @@ mod tests {
     use crate::error::StoreError;
     use crate::msg::ExecuteMsg::{DeleteData, InsertData};
     use crate::msg::Node::{BlankNode, NamedNode};
-    use crate::msg::SimpleWhereCondition::TriplePattern;
     use crate::msg::IRI::{Full, Prefixed};
     use crate::msg::{
         ConstructQuery, ConstructResponse, DescribeQuery, DescribeResponse, Head, Literal, Prefix,
         Results, SelectItem, SelectQuery, SelectResponse, StoreLimitsInput,
         StoreLimitsInputBuilder, StoreResponse, Value, VarOrNamedNode, VarOrNamedNodeOrLiteral,
-        VarOrNode, VarOrNodeOrLiteral, WhereCondition,
+        VarOrNode, VarOrNodeOrLiteral,
     };
+    use crate::msg::{TriplePattern, WhereClause};
     use crate::state::{
         namespaces, triples, Namespace, Node, Object, StoreLimits, StoreStat, Subject, Triple,
     };
@@ -531,7 +535,7 @@ mod tests {
             DeleteData {
                 prefixes: vec![],
                 delete: vec![],
-                r#where: vec![],
+                r#where: None,
             },
         ];
 
@@ -910,18 +914,21 @@ mod tests {
                             "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
                         )),
                     }],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Node(NamedNode(Full(
-                            "https://ontology.axone.space/dataverse/dataspace/metadata/unknown"
-                                .to_string(),
-                        ))),
-                        predicate: VarOrNamedNode::NamedNode(Full(
-                            "https://ontology.axone.space/core/hasTopic".to_string(),
-                        )),
-                        object: VarOrNodeOrLiteral::Node(NamedNode(Full(
-                            "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
-                        ))),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Node(NamedNode(Full(
+                                "https://ontology.axone.space/dataverse/dataspace/metadata/unknown"
+                                    .to_string(),
+                            ))),
+                            predicate: VarOrNamedNode::NamedNode(Full(
+                                "https://ontology.axone.space/core/hasTopic".to_string(),
+                            )),
+                            object: VarOrNodeOrLiteral::Node(NamedNode(Full(
+                                "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
+                            ))),
+                        }],
+                    }
+                    .into(),
                 },
                 0,
                 0,
@@ -939,15 +946,18 @@ mod tests {
                             "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
                         )),
                     }],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
-                        predicate: VarOrNamedNode::NamedNode(Full(
-                            "https://ontology.axone.space/core/hasTopic".to_string(),
-                        )),
-                        object: VarOrNodeOrLiteral::Node(NamedNode(Full(
-                            "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
-                        ))),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
+                            predicate: VarOrNamedNode::NamedNode(Full(
+                                "https://ontology.axone.space/core/hasTopic".to_string(),
+                            )),
+                            object: VarOrNodeOrLiteral::Node(NamedNode(Full(
+                                "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
+                            ))),
+                        }],
+                    }
+                    .into(),
                 },
                 1,
                 0,
@@ -972,13 +982,18 @@ mod tests {
                             "thesaurus:Test".to_string(),
                         )),
                     }],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
-                        predicate: VarOrNamedNode::NamedNode(Prefixed("core:hasTopic".to_string())),
-                        object: VarOrNodeOrLiteral::Node(NamedNode(Prefixed(
-                            "thesaurus:Test".to_string(),
-                        ))),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
+                            predicate: VarOrNamedNode::NamedNode(Prefixed(
+                                "core:hasTopic".to_string(),
+                            )),
+                            object: VarOrNodeOrLiteral::Node(NamedNode(Prefixed(
+                                "thesaurus:Test".to_string(),
+                            ))),
+                        }],
+                    }
+                    .into(),
                 },
                 1,
                 0,
@@ -1001,11 +1016,16 @@ mod tests {
                         predicate: VarOrNamedNode::NamedNode(Prefixed("core:hasTopic".to_string())),
                         object: VarOrNamedNodeOrLiteral::Variable("o".to_string()),
                     }],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
-                        predicate: VarOrNamedNode::NamedNode(Prefixed("core:hasTopic".to_string())),
-                        object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
+                            predicate: VarOrNamedNode::NamedNode(Prefixed(
+                                "core:hasTopic".to_string(),
+                            )),
+                            object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                        }],
+                    }
+                    .into(),
                 },
                 1,
                 0,
@@ -1019,11 +1039,14 @@ mod tests {
                         predicate: VarOrNamedNode::Variable("p".to_string()),
                         object: VarOrNamedNodeOrLiteral::Variable("o".to_string()),
                     }],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
-                        predicate: VarOrNamedNode::Variable("p".to_string()),
-                        object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
+                            predicate: VarOrNamedNode::Variable("p".to_string()),
+                            object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                        }],
+                    }
+                    .into(),
                 },
                 11,
                 2,
@@ -1033,11 +1056,14 @@ mod tests {
                 DeleteData {
                     prefixes: vec![],
                     delete: vec![],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
-                        predicate: VarOrNamedNode::Variable("p".to_string()),
-                        object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
+                            predicate: VarOrNamedNode::Variable("p".to_string()),
+                            object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                        }],
+                    }
+                    .into(),
                 },
                 11,
                 2,
@@ -1047,11 +1073,14 @@ mod tests {
                 DeleteData {
                     prefixes: vec![],
                     delete: vec![],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Variable("s".to_string()),
-                        predicate: VarOrNamedNode::Variable("p".to_string()),
-                        object: VarOrNodeOrLiteral::Variable("0".to_string()),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Variable("s".to_string()),
+                            predicate: VarOrNamedNode::Variable("p".to_string()),
+                            object: VarOrNodeOrLiteral::Variable("0".to_string()),
+                        }],
+                    }
+                    .into(),
                 },
                 40,
                 17,
@@ -1076,7 +1105,7 @@ mod tests {
                             "thesaurus:Test".to_string(),
                         )),
                     }],
-                    r#where: vec![],
+                    r#where: None,
                 },
                 1,
                 0,
@@ -1160,15 +1189,18 @@ mod tests {
                             "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
                         )),
                     }],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Node(NamedNode(Prefixed("foo:bar".to_string()))),
-                        predicate: VarOrNamedNode::NamedNode(Full(
-                            "https://ontology.axone.space/core/hasTopic".to_string(),
-                        )),
-                        object: VarOrNodeOrLiteral::Node(NamedNode(Full(
-                            "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
-                        ))),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Node(NamedNode(Prefixed("foo:bar".to_string()))),
+                            predicate: VarOrNamedNode::NamedNode(Full(
+                                "https://ontology.axone.space/core/hasTopic".to_string(),
+                            )),
+                            object: VarOrNodeOrLiteral::Node(NamedNode(Full(
+                                "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
+                            ))),
+                        }],
+                    }
+                    .into(),
                 },
                 expected: StdError::generic_err("Prefix not found: foo").into(),
             },
@@ -1182,13 +1214,16 @@ mod tests {
                         predicate: VarOrNamedNode::Variable("z".to_string()),
                         object: VarOrNamedNodeOrLiteral::Variable("o".to_string()),
                     }],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Node(NamedNode(Full(
-                            "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
-                        ))),
-                        predicate: VarOrNamedNode::Variable("p".to_string()),
-                        object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Node(NamedNode(Full(
+                                "https://ontology.axone.space/thesaurus/topic/Test".to_string(),
+                            ))),
+                            predicate: VarOrNamedNode::Variable("p".to_string()),
+                            object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                        }],
+                    }
+                    .into(),
                 },
                 expected: StdError::generic_err("Selected variable not found in query").into(),
             },
@@ -1299,15 +1334,14 @@ mod tests {
                         SelectItem::Variable("a".to_string()),
                         SelectItem::Variable("b".to_string()),
                     ],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(
-                        msg::TriplePattern {
+                    r#where: WhereClause::Bgp{patterns:vec![TriplePattern {
                             subject: VarOrNode::Variable("a".to_string()),
                             predicate: VarOrNamedNode::NamedNode(Full(
                                 "https://ontology.axone.space/core/hasDescription".to_string(),
                             )),
                             object: VarOrNodeOrLiteral::Variable("b".to_string()),
                         },
-                    ))],
+                    ]},
                     limit: None,
                 },
                 SelectResponse {
@@ -1390,15 +1424,14 @@ mod tests {
                     select: vec![
                         SelectItem::Variable("a".to_string()),
                     ],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(
-                        msg::TriplePattern {
+                    r#where: WhereClause::Bgp{patterns:vec![TriplePattern {
                             subject: VarOrNode::Variable("a".to_string()),
                             predicate: VarOrNamedNode::NamedNode(Prefixed(
                                 "core:hasDescription".to_string(),
                             )),
                             object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString { value: "A test Dataset.".to_string(), language: "en".to_string() }),
                         },
-                    ))],
+                    ]},
                     limit: None,
                 },
                 SelectResponse {
@@ -1425,13 +1458,12 @@ mod tests {
                     select: vec![
                         SelectItem::Variable("a".to_string()),
                     ],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(
-                        msg::TriplePattern {
+                    r#where: WhereClause::Bgp{patterns:vec![TriplePattern {
                             subject: VarOrNode::Node(NamedNode(Full("https://ontology.axone.space/dataverse/dataset/metadata/d1615703-4ee1-4e2f-997e-15aecf1eea4e".to_string()))),
                             predicate: VarOrNamedNode::Variable("a".to_string()),
                             object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString { value: "A test Dataset.".to_string(), language: "en".to_string() }),
                         },
-                    ))],
+                    ]},
                     limit: None,
                 },
                 SelectResponse {
@@ -1492,25 +1524,22 @@ mod tests {
                 SelectQuery {
                     prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.axone.space/core/".to_string() }],
                     select: vec![SelectItem::Variable("a".to_string()), SelectItem::Variable("b".to_string())],
-                    r#where: vec![
-                        WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                    r#where: WhereClause::Bgp{patterns:vec![
+                        TriplePattern {
                                 subject: VarOrNode::Variable("a".to_string()),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasTemporalCoverage".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Node(BlankNode("a".to_string())),
                             },
-                        )),
-                        WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                        TriplePattern {
                                 subject: VarOrNode::Node(BlankNode("a".to_string())),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasStartDate".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Variable("b".to_string()),
                             },
-                        ))],
+                        ]},
                     limit: None,
                 },
                 SelectResponse {
@@ -1541,25 +1570,22 @@ mod tests {
                 SelectQuery {
                     prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.axone.space/core/".to_string() }],
                     select: vec![SelectItem::Variable("a".to_string()), SelectItem::Variable("b".to_string())],
-                    r#where: vec![
-                        WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                    r#where: WhereClause::Bgp{patterns:vec![
+                        TriplePattern {
                                 subject: VarOrNode::Variable("a".to_string()),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasTemporalCoverage".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Variable("blank".to_string()),
                             },
-                        )),
-                        WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                        TriplePattern {
                                 subject: VarOrNode::Variable("blank".to_string()),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasStartDate".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Variable("b".to_string()),
-                            },
-                        ))],
+                            }
+                    ]},
                     limit: None,
                 },
                 SelectResponse {
@@ -1590,25 +1616,22 @@ mod tests {
                 SelectQuery {
                     prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.axone.space/core/".to_string() }],
                     select: vec![SelectItem::Variable("a".to_string()), SelectItem::Variable("b".to_string())],
-                    r#where: vec![
-                        WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                    r#where: WhereClause::Bgp{patterns:vec![
+                        TriplePattern {
                                 subject: VarOrNode::Variable("a".to_string()),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasTemporalCoverage".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Node(BlankNode("blank1".to_string())),
                             },
-                        )),
-                        WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                        TriplePattern {
                                 subject: VarOrNode::Node(BlankNode("blank2".to_string())),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasInformation".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Variable("b".to_string()),
                             },
-                        ))],
+                    ]},
                     limit: None,
                 },
                 SelectResponse {
@@ -1639,16 +1662,15 @@ mod tests {
                 SelectQuery {
                     prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.axone.space/core/".to_string() }],
                     select: vec![SelectItem::Variable("a".to_string()), SelectItem::Variable("b".to_string())],
-                    r#where: vec![
-                        WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                    r#where: WhereClause::Bgp{patterns:vec![
+                        TriplePattern {
                                 subject: VarOrNode::Variable("a".to_string()),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasTemporalCoverage".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Variable("b".to_string()),
                             },
-                        ))],
+                        ]},
                     limit: None,
                 },
                 SelectResponse {
@@ -1716,7 +1738,7 @@ mod tests {
                         SelectItem::Variable("a".to_string()),
                         SelectItem::Variable("b".to_string()),
                     ],
-                    r#where: vec![],
+                    r#where: WhereClause::Bgp { patterns: vec![] },
                     limit: None,
                 },
                 Err(StdError::generic_err(
@@ -1727,7 +1749,7 @@ mod tests {
                 SelectQuery {
                     prefixes: vec![],
                     select: vec![],
-                    r#where: vec![],
+                    r#where: WhereClause::Bgp { patterns: vec![] },
                     limit: Some(8000),
                 },
                 Err(StdError::generic_err("Maximum query limit exceeded")),
@@ -1739,16 +1761,18 @@ mod tests {
                         namespace: "https://ontology.axone.space/core/".to_string(),
                     }],
                     select: vec![SelectItem::Variable("a".to_string())],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Variable("a".to_string()),
-                        predicate: VarOrNamedNode::NamedNode(Prefixed(
-                            "invalid:hasDescription".to_string(),
-                        )),
-                        object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString {
-                            value: "A test Dataset.".to_string(),
-                            language: "en".to_string(),
-                        }),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Variable("a".to_string()),
+                            predicate: VarOrNamedNode::NamedNode(Prefixed(
+                                "invalid:hasDescription".to_string(),
+                            )),
+                            object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString {
+                                value: "A test Dataset.".to_string(),
+                                language: "en".to_string(),
+                            }),
+                        }],
+                    },
                     limit: None,
                 },
                 Err(StdError::generic_err("Prefix not found: invalid")),
@@ -1757,16 +1781,18 @@ mod tests {
                 SelectQuery {
                     prefixes: vec![],
                     select: vec![SelectItem::Variable("u".to_string())],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Variable("a".to_string()),
-                        predicate: VarOrNamedNode::NamedNode(Full(
-                            "https://ontology.axone.space/core/hasDescription".to_string(),
-                        )),
-                        object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString {
-                            value: "A test Dataset.".to_string(),
-                            language: "en".to_string(),
-                        }),
-                    }))],
+                    r#where: WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Variable("a".to_string()),
+                            predicate: VarOrNamedNode::NamedNode(Full(
+                                "https://ontology.axone.space/core/hasDescription".to_string(),
+                            )),
+                            object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString {
+                                value: "A test Dataset.".to_string(),
+                                language: "en".to_string(),
+                            }),
+                        }],
+                    },
                     limit: None,
                 },
                 Err(StdError::generic_err(
@@ -1816,7 +1842,7 @@ mod tests {
                     query: DescribeQuery {
                         prefixes: vec![],
                         resource: VarOrNamedNode::NamedNode(Full("https://ontology.axone.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
-                        r#where: vec![],
+                        r#where: None,
                     },
                     format: Some(DataFormat::Turtle),
                 },
@@ -1839,7 +1865,7 @@ mod tests {
                     query: DescribeQuery {
                         prefixes: vec![],
                         resource: VarOrNamedNode::NamedNode(Full("https://ontology.axone.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
-                        r#where: vec![],
+                        r#where: None,
                     },
                     format: Some(DataFormat::RDFXml),
                 },
@@ -1868,15 +1894,15 @@ mod tests {
                     query: DescribeQuery {
                         prefixes: vec![],
                         resource: VarOrNamedNode::NamedNode(Full("https://ontology.axone.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
-                        r#where: vec![WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                        r#where: WhereClause::Bgp { patterns: vec![
+                            TriplePattern {
                                 subject: VarOrNode::Variable("a".to_string()),
                                 predicate: VarOrNamedNode::NamedNode(Full(
                                     "https://ontology.axone.space/core/hasDescription".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Variable("b".to_string()),
                             },
-                        ))],
+                        ]}.into(),
                     },
                     format: Some(DataFormat::NTriples),
                 },
@@ -1903,7 +1929,7 @@ mod tests {
                     query: DescribeQuery {
                         prefixes: vec![],
                         resource: VarOrNamedNode::NamedNode(Full("https://ontology.axone.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
-                        r#where: vec![],
+                        r#where: None,
                     },
                     format: Some(DataFormat::NQuads),
                 },
@@ -1977,7 +2003,7 @@ mod tests {
                             },
                         ],
                         resource: VarOrNamedNode::NamedNode(Prefixed("metadata:dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
-                        r#where: vec![],
+                        r#where: None,
                     },
                     format: Some(DataFormat::Turtle),
                 },
@@ -2042,15 +2068,15 @@ mod tests {
                     query: DescribeQuery {
                         prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.axone.space/core/".to_string() }],
                         resource: VarOrNamedNode::Variable("a".to_string()),
-                        r#where: vec![WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                        r#where: WhereClause::Bgp {patterns: vec![
+                            TriplePattern {
                                 subject: VarOrNode::Variable("a".to_string()),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasDescription".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString { value: "A test Dataset.".to_string(), language: "en".to_string() }),
                             },
-                        ))],
+                        ]}.into(),
                     },
                     format: Some(DataFormat::Turtle),
                 },
@@ -2100,22 +2126,22 @@ mod tests {
     }
 
     #[test]
-    fn variable_mutiple_resources_describe() {
+    fn variable_multiple_resources_describe() {
         let cases = vec![
             (
                 QueryMsg::Describe {
                     query: DescribeQuery {
                         prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.axone.space/core/".to_string() }],
                         resource: VarOrNamedNode::Variable("a".to_string()),
-                        r#where: vec![WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                        r#where: WhereClause::Bgp {patterns: vec![
+                            TriplePattern {
                                 subject: VarOrNode::Variable("a".to_string()),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasPublisher".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Literal(Literal::Simple("AXONE".to_string())),
                             },
-                        ))],
+                        ]}.into(),
                     },
                     format: Some(DataFormat::Turtle),
                 },
@@ -2175,16 +2201,15 @@ mod tests {
                             Prefix { prefix: "metadata-dataset".to_string(), namespace: "https://ontology.axone.space/dataverse/dataset/metadata/".to_string() },
                         ],
                         resource: VarOrNamedNode::Variable("x".to_string()),
-                        r#where: vec![WhereCondition::Simple(TriplePattern(
-                            msg::TriplePattern {
+                        r#where: WhereClause::Bgp {patterns: vec![
+                            TriplePattern {
                                 subject: VarOrNode::Node(NamedNode(Prefixed("metadata-dataset:80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string()))),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasTemporalCoverage".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Variable("x".to_string()),
                             },
-                        )),
-                        ],
+                        ]}.into(),
                     },
                     format: Some(DataFormat::Turtle),
                 },
@@ -2246,13 +2271,13 @@ mod tests {
                     query: ConstructQuery {
                         prefixes: vec![],
                         construct: vec![],
-                        r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                        r#where: WhereClause::Bgp{patterns:vec![TriplePattern {
                             subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
                             predicate: VarOrNamedNode::NamedNode(Full(
                                 "https://ontology.axone.space/core/hasTag".to_string(),
                             )),
                             object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                        }))],
+                        }]},
                     },
                     format: None,
                 },
@@ -2282,13 +2307,13 @@ mod tests {
                                 object: VarOrNodeOrLiteral::Variable("o".to_string()),
                             }
                         ],
-                        r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                        r#where: WhereClause::Bgp{patterns:vec![TriplePattern {
                             subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
                             predicate: VarOrNamedNode::NamedNode(Full(
                                 "https://ontology.axone.space/core/hasTag".to_string(),
                             )),
                             object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                        }))],
+                        }]},
                     },
                     format: Some(DataFormat::NTriples),
                 },
@@ -2335,32 +2360,32 @@ mod tests {
                                 object: VarOrNodeOrLiteral::Variable("info_o".to_string()),
                             }
                         ],
-                        r#where: vec![
-                            WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                        r#where: WhereClause::Bgp {patterns:vec![
+                            TriplePattern {
                                 subject: VarOrNode::Node(NamedNode(Prefixed("metadata-dataset:80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string()))),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasTemporalCoverage".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Variable("tcov".to_string()),
-                            })),
-                            WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                            },
+                            TriplePattern {
                                 subject: VarOrNode::Node(NamedNode(Prefixed("metadata-dataset:80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string()))),
                                 predicate: VarOrNamedNode::NamedNode(Prefixed(
                                     "core:hasInformations".to_string(),
                                 )),
                                 object: VarOrNodeOrLiteral::Variable("info".to_string()),
-                            })),
-                            WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                            },
+                            TriplePattern {
                                 subject: VarOrNode::Variable("tcov".to_string()),
                                 predicate: VarOrNamedNode::Variable("tcov_p".to_string()),
                                 object: VarOrNodeOrLiteral::Variable("tcov_o".to_string()),
-                            })),
-                            WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                            },
+                            TriplePattern {
                                 subject: VarOrNode::Variable("info".to_string()),
                                 predicate: VarOrNamedNode::Variable("info_p".to_string()),
                                 object: VarOrNodeOrLiteral::Variable("info_o".to_string()),
-                            }))
-                        ],
+                            }
+                        ]},
                     },
                     format: Some(DataFormat::NTriples),
                 },

--- a/contracts/axone-cognitarium/src/msg.rs
+++ b/contracts/axone-cognitarium/src/msg.rs
@@ -510,6 +510,8 @@ pub enum Expression {
     Less(Box<Self>, Box<Self>),
     /// Less or equal comparison.
     LessOrEqual(Box<Self>, Box<Self>),
+    /// Negation of an expression.
+    Not(Box<Self>),
 }
 
 /// # TripleDeleteTemplate

--- a/contracts/axone-cognitarium/src/msg.rs
+++ b/contracts/axone-cognitarium/src/msg.rs
@@ -464,7 +464,7 @@ pub enum SelectItem {
 }
 
 /// # WhereClause
-/// Represents a WHERE clause in a [SelectQuery], i.e. a set of conditions to filter the results.
+/// Represents a WHERE clause, i.e. a set of conditions to filter the results.
 #[cw_serde]
 pub enum WhereClause {
     /// # Bgp
@@ -474,6 +474,42 @@ pub enum WhereClause {
     /// # LateralJoin
     /// Evaluates right for all result row of left
     LateralJoin { left: Box<Self>, right: Box<Self> },
+
+    /// # Filter
+    /// Filters the inner clause matching the expression.
+    /// The solutions coming from the inner clause that do not match the expression are discarded.
+    /// The variables provided in the inner clause are available in the filter expression.
+    Filter { expr: Expression, inner: Box<Self> },
+}
+
+/// # Expression
+/// Represents a logical combination of operations whose evaluation results in a term.
+#[cw_serde]
+pub enum Expression {
+    /// A named node constant.
+    NamedNode(IRI),
+    /// A literal constant.
+    Literal(Literal),
+    /// A variable that must be bound for evaluation.
+    Variable(String),
+    /// Logical conjunction of expressions.
+    /// All expressions must evaluate to true for the conjunction to be true.
+    /// If the conjunction is empty, it is considered true.
+    And(Vec<Self>),
+    /// Logical disjunction of expressions.
+    /// At least one expression must evaluate to true for the disjunction to be true.
+    /// If the disjunction is empty, it is considered false.
+    Or(Vec<Self>),
+    /// Equality comparison.
+    Equal(Box<Self>, Box<Self>),
+    /// Greater than comparison.
+    Greater(Box<Self>, Box<Self>),
+    /// Greater or equal comparison.
+    GreaterOrEqual(Box<Self>, Box<Self>),
+    /// Less than comparison.
+    Less(Box<Self>, Box<Self>),
+    /// Less or equal comparison.
+    LessOrEqual(Box<Self>, Box<Self>),
 }
 
 /// # TripleDeleteTemplate

--- a/contracts/axone-cognitarium/src/msg.rs
+++ b/contracts/axone-cognitarium/src/msg.rs
@@ -68,11 +68,12 @@ pub enum ExecuteMsg {
         /// The prefixes used in the operation.
         prefixes: Vec<Prefix>,
         /// Specifies the specific triple templates to delete.
-        /// If nothing is provided, the patterns from the `where` clause are used for deletion.
+        /// If nothing is provided and the `where` clause is a single Bgp, the patterns are used for
+        /// deletion.
         delete: Vec<TripleDeleteTemplate>,
         /// Defines the patterns that data (RDF triples) should match in order for it to be
-        /// considered for deletion.
-        r#where: WhereClause,
+        /// considered for deletion, if any.
+        r#where: Option<WhereClause>,
     },
 }
 
@@ -424,7 +425,7 @@ pub struct DescribeQuery {
     pub resource: VarOrNamedNode,
     /// The WHERE clause.
     /// This clause is used to specify the resource identifier to describe using variable bindings.
-    pub r#where: WhereClause,
+    pub r#where: Option<WhereClause>,
 }
 
 /// # ConstructQuery
@@ -435,7 +436,8 @@ pub struct ConstructQuery {
     /// The prefixes used in the query.
     pub prefixes: Vec<Prefix>,
     /// The triples to construct.
-    /// If nothing is provided, the patterns from the `where` clause are used for construction.
+    /// If nothing is provided and the `where` clause is a single Bgp, the patterns are used for
+    /// construction.
     pub construct: Vec<TripleConstructTemplate>,
     /// The WHERE clause.
     /// This clause is used to specify the triples to construct using variable bindings.
@@ -463,25 +465,15 @@ pub enum SelectItem {
 
 /// # WhereClause
 /// Represents a WHERE clause in a [SelectQuery], i.e. a set of conditions to filter the results.
-pub type WhereClause = Vec<WhereCondition>;
-
-/// # WhereCondition
-/// Represents a condition in a [WhereClause].
 #[cw_serde]
-pub enum WhereCondition {
-    /// # Simple
-    /// Represents a simple condition.
-    Simple(SimpleWhereCondition),
-}
+pub enum WhereClause {
+    /// # Bgp
+    /// Represents a basic graph pattern expressed as a set of triple patterns.
+    Bgp { patterns: Vec<TriplePattern> },
 
-/// # SimpleWhereCondition
-/// Represents a simple condition in a [WhereCondition].
-#[cw_serde]
-pub enum SimpleWhereCondition {
-    /// # TriplePattern
-    /// Represents a triple pattern, i.e. a condition on a triple based on its subject, predicate and
-    /// object.
-    TriplePattern(TriplePattern),
+    /// # LateralJoin
+    /// Evaluates right for all result row of left
+    LateralJoin { left: Box<Self>, right: Box<Self> },
 }
 
 /// # TripleDeleteTemplate

--- a/contracts/axone-cognitarium/src/querier/engine.rs
+++ b/contracts/axone-cognitarium/src/querier/engine.rs
@@ -71,7 +71,7 @@ impl<'a> QueryEngine<'a> {
 
         Ok(ResolvedAtomIterator::new(
             self.storage,
-            self.ns_cache.clone().into(),
+            self.ns_cache.clone(),
             IdentifierIssuer::new("b", 0u128),
             self.eval_plan(plan),
             templates,
@@ -201,7 +201,7 @@ impl<'a> FilterIterator<'a> {
         Self {
             upstream,
             expr,
-            ns_resolver: NamespaceResolver::new(storage, ns_cache.into()),
+            ns_resolver: NamespaceResolver::new(storage, ns_cache),
         }
     }
 }
@@ -793,7 +793,7 @@ impl<'a> ResolvedAtomIterator<'a> {
         templates: Vec<AtomTemplate>,
     ) -> Self {
         Self {
-            ns_resolver: NamespaceResolver::new(storage, ns_cache.into()),
+            ns_resolver: NamespaceResolver::new(storage, ns_cache),
             id_issuer,
             upstream_iter,
             templates,

--- a/contracts/axone-cognitarium/src/querier/expression.rs
+++ b/contracts/axone-cognitarium/src/querier/expression.rs
@@ -1,0 +1,153 @@
+use crate::msg;
+use crate::querier::mapper::iri_as_string;
+use crate::querier::ResolvedVariables;
+use crate::state::NamespaceSolver;
+use cosmwasm_std::{StdError, StdResult};
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashMap};
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub enum Expression {
+    Constant(Term),
+    Variable(usize),
+    And(Vec<Self>),
+    Or(Vec<Self>),
+    Equal(Box<Self>, Box<Self>),
+    Greater(Box<Self>, Box<Self>),
+    GreaterOrEqual(Box<Self>, Box<Self>),
+    Less(Box<Self>, Box<Self>),
+    LessOrEqual(Box<Self>, Box<Self>),
+}
+
+impl Expression {
+    pub fn bound_variables(&self) -> BTreeSet<usize> {
+        let mut vars = BTreeSet::new();
+        self.lookup_bound_variables(&mut |v| {
+            vars.insert(v);
+        });
+        vars
+    }
+
+    pub fn lookup_bound_variables(&self, callback: &mut impl FnMut(usize)) {
+        match self {
+            Expression::Constant(_) => {}
+            Expression::Variable(v) => {
+                callback(*v);
+            }
+            Expression::And(exprs) | Expression::Or(exprs) => {
+                exprs
+                    .iter()
+                    .for_each(|e| e.lookup_bound_variables(callback));
+            }
+            Expression::Equal(left, right)
+            | Expression::Greater(left, right)
+            | Expression::GreaterOrEqual(left, right)
+            | Expression::Less(left, right)
+            | Expression::LessOrEqual(left, right) => {
+                left.lookup_bound_variables(callback);
+                right.lookup_bound_variables(callback);
+            }
+        }
+    }
+
+    pub fn evaluate<'a>(
+        &self,
+        vars: &'a ResolvedVariables,
+        ns_solver: &mut dyn NamespaceSolver,
+    ) -> StdResult<Term> {
+        match self {
+            Expression::Constant(term) => Ok(term.clone()),
+            Expression::Variable(v) => vars
+                .get(*v)
+                .clone()
+                .ok_or(StdError::generic_err("Unbound filter variable"))
+                .and_then(|v| v.as_term(ns_solver)),
+            Expression::And(exprs) => {
+                for expr in exprs {
+                    if !expr.evaluate(vars, ns_solver)?.as_bool() {
+                        return Ok(Term::Boolean(false));
+                    }
+                }
+                return Ok(Term::Boolean(true));
+            }
+            Expression::Or(exprs) => {
+                for expr in exprs {
+                    if expr.evaluate(vars, ns_solver)?.as_bool() {
+                        return Ok(Term::Boolean(true));
+                    }
+                }
+                return Ok(Term::Boolean(false));
+            }
+            Expression::Equal(left, right) => Ok(Term::Boolean(
+                left.evaluate(vars, ns_solver)? == right.evaluate(vars, ns_solver)?,
+            )),
+            Expression::Greater(left, right) => Ok(Term::Boolean(
+                left.evaluate(vars, ns_solver)? > right.evaluate(vars, ns_solver)?,
+            )),
+            Expression::GreaterOrEqual(left, right) => Ok(Term::Boolean(
+                left.evaluate(vars, ns_solver)? >= right.evaluate(vars, ns_solver)?,
+            )),
+            Expression::Less(left, right) => Ok(Term::Boolean(
+                left.evaluate(vars, ns_solver)? < right.evaluate(vars, ns_solver)?,
+            )),
+            Expression::LessOrEqual(left, right) => Ok(Term::Boolean(
+                left.evaluate(vars, ns_solver)? <= right.evaluate(vars, ns_solver)?,
+            )),
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub enum Term {
+    String(String),
+    Boolean(bool),
+}
+
+impl Term {
+    pub fn from_iri(iri: msg::IRI, prefixes: &HashMap<String, String>) -> StdResult<Self> {
+        Ok(Term::String(iri_as_string(iri, prefixes)?))
+    }
+
+    pub fn from_literal(
+        literal: msg::Literal,
+        prefixes: &HashMap<String, String>,
+    ) -> StdResult<Self> {
+        Ok(Term::String(match literal {
+            msg::Literal::Simple(value) => value,
+            msg::Literal::LanguageTaggedString { value, language } => {
+                format!("{}{}", value, language).to_string()
+            }
+            msg::Literal::TypedValue { value, datatype } => {
+                format!("{}{}", value, iri_as_string(datatype, prefixes)?).to_string()
+            }
+        }))
+    }
+
+    pub fn as_string(&self) -> String {
+        match self {
+            Term::String(t) => t.clone(),
+            Term::Boolean(b) => b.to_string(),
+        }
+    }
+
+    pub fn as_bool(&self) -> bool {
+        match self {
+            Term::String(s) => !s.is_empty(),
+            Term::Boolean(b) => *b,
+        }
+    }
+}
+
+impl PartialOrd<Term> for Term {
+    fn partial_cmp(&self, other: &Term) -> Option<Ordering> {
+        if self == other {
+            return Some(Ordering::Equal);
+        }
+
+        match (self, other) {
+            (Term::String(left), Term::String(right)) => Some(left.cmp(right)),
+            (Term::Boolean(left), Term::Boolean(right)) => Some(left.cmp(right)),
+            _ => None,
+        }
+    }
+}

--- a/contracts/axone-cognitarium/src/querier/expression.rs
+++ b/contracts/axone-cognitarium/src/querier/expression.rs
@@ -22,9 +22,9 @@ pub enum Expression {
 }
 
 impl Expression {
-    pub fn evaluate<'a>(
+    pub fn evaluate(
         &self,
-        vars: &'a ResolvedVariables,
+        vars: &ResolvedVariables,
         ns_solver: &mut dyn NamespaceSolver,
     ) -> StdResult<Term> {
         match self {
@@ -40,7 +40,7 @@ impl Expression {
                         return Ok(Term::Boolean(false));
                     }
                 }
-                return Ok(Term::Boolean(true));
+                Ok(Term::Boolean(true))
             }
             Expression::Or(exprs) => {
                 for expr in exprs {
@@ -48,7 +48,7 @@ impl Expression {
                         return Ok(Term::Boolean(true));
                     }
                 }
-                return Ok(Term::Boolean(false));
+                Ok(Term::Boolean(false))
             }
             Expression::Equal(left, right) => Ok(Term::Boolean(
                 left.evaluate(vars, ns_solver)? == right.evaluate(vars, ns_solver)?,
@@ -115,10 +115,10 @@ impl Term {
         Ok(Term::String(match literal {
             msg::Literal::Simple(value) => value,
             msg::Literal::LanguageTaggedString { value, language } => {
-                format!("{}{}", value, language).to_string()
+                format!("{}{}", value, language)
             }
             msg::Literal::TypedValue { value, datatype } => {
-                format!("{}{}", value, iri_as_string(datatype, prefixes)?).to_string()
+                format!("{}{}", value, iri_as_string(datatype, prefixes)?)
             }
         }))
     }

--- a/contracts/axone-cognitarium/src/querier/mod.rs
+++ b/contracts/axone-cognitarium/src/querier/mod.rs
@@ -1,4 +1,5 @@
 mod engine;
+mod expression;
 mod mapper;
 mod plan;
 mod plan_builder;

--- a/contracts/axone-cognitarium/src/querier/mod.rs
+++ b/contracts/axone-cognitarium/src/querier/mod.rs
@@ -5,5 +5,6 @@ mod plan_builder;
 mod variable;
 
 pub use engine::*;
+pub use plan::*;
 pub use plan_builder::*;
 pub use variable::ResolvedVariables;

--- a/contracts/axone-cognitarium/src/querier/plan.rs
+++ b/contracts/axone-cognitarium/src/querier/plan.rs
@@ -1,3 +1,4 @@
+use crate::querier::expression::Expression;
 use crate::state::{Object, Predicate, Subject};
 use std::collections::BTreeSet;
 
@@ -73,6 +74,9 @@ pub enum QueryNode {
     /// left node to use them as right node values.
     ForLoopJoin { left: Box<Self>, right: Box<Self> },
 
+    /// Filter the results of the inner node by applying the expression.
+    Filter { expr: Expression, inner: Box<Self> },
+
     /// Skip the specified first elements from the child node.
     Skip { child: Box<Self>, first: usize },
 
@@ -113,6 +117,10 @@ impl QueryNode {
             | QueryNode::ForLoopJoin { left, right } => {
                 left.lookup_bound_variables(callback);
                 right.lookup_bound_variables(callback);
+            }
+            QueryNode::Filter { expr, inner } => {
+                expr.lookup_bound_variables(callback);
+                inner.lookup_bound_variables(callback);
             }
             QueryNode::Skip { child, .. } | QueryNode::Limit { child, .. } => {
                 child.lookup_bound_variables(callback);

--- a/contracts/axone-cognitarium/src/querier/plan.rs
+++ b/contracts/axone-cognitarium/src/querier/plan.rs
@@ -1,7 +1,6 @@
 use crate::querier::expression::Expression;
 use crate::querier::variable::HasBoundVariables;
 use crate::state::{Object, Predicate, Subject};
-use std::collections::BTreeSet;
 
 /// Represents a querying plan.
 #[derive(Eq, PartialEq, Debug, Clone)]
@@ -143,6 +142,7 @@ impl<V> PatternValue<V> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     #[test]
     fn bound_variables() {

--- a/contracts/axone-cognitarium/src/querier/plan.rs
+++ b/contracts/axone-cognitarium/src/querier/plan.rs
@@ -1,4 +1,5 @@
 use crate::querier::expression::Expression;
+use crate::querier::variable::HasBoundVariables;
 use crate::state::{Object, Predicate, Subject};
 use std::collections::BTreeSet;
 
@@ -90,16 +91,10 @@ impl QueryNode {
             bound_variables: Vec::new(),
         }
     }
+}
 
-    pub fn bound_variables(&self) -> BTreeSet<usize> {
-        let mut vars = BTreeSet::new();
-        self.lookup_bound_variables(&mut |v| {
-            vars.insert(v);
-        });
-        vars
-    }
-
-    pub fn lookup_bound_variables(&self, callback: &mut impl FnMut(usize)) {
+impl HasBoundVariables for QueryNode {
+    fn lookup_bound_variables(&self, callback: &mut impl FnMut(usize)) {
         match self {
             QueryNode::TriplePattern {
                 subject,

--- a/contracts/axone-cognitarium/src/querier/plan.rs
+++ b/contracts/axone-cognitarium/src/querier/plan.rs
@@ -20,6 +20,13 @@ pub enum PlanVariable {
 }
 
 impl QueryPlan {
+    pub fn empty_plan() -> Self {
+        Self {
+            entrypoint: QueryNode::noop(),
+            variables: Vec::new(),
+        }
+    }
+
     /// Resolve the index corresponding to the variable name, if not attached to a blank node.
     pub fn get_var_index(&self, var_name: &str) -> Option<usize> {
         self.variables.iter().enumerate().find_map(|(index, it)| {
@@ -74,6 +81,12 @@ pub enum QueryNode {
 }
 
 impl QueryNode {
+    pub fn noop() -> Self {
+        QueryNode::Noop {
+            bound_variables: Vec::new(),
+        }
+    }
+
     pub fn bound_variables(&self) -> BTreeSet<usize> {
         let mut vars = BTreeSet::new();
         self.lookup_bound_variables(&mut |v| {

--- a/contracts/axone-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/axone-cognitarium/src/querier/plan_builder.rs
@@ -157,6 +157,10 @@ impl<'a> PlanBuilder<'a> {
                 Box::new(self.build_expression(left)?),
                 Box::new(self.build_expression(right)?),
             )),
+            msg::Expression::Not(child) => self
+                .build_expression(child)
+                .map(Box::new)
+                .map(Expression::Not),
         }
     }
 

--- a/contracts/axone-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/axone-cognitarium/src/querier/plan_builder.rs
@@ -25,7 +25,7 @@ impl<'a> PlanBuilder<'a> {
         ns_cache: Option<Vec<Namespace>>,
     ) -> Self {
         Self {
-            ns_resolver: NamespaceResolver::new(storage, ns_cache.unwrap_or(vec![]).into()),
+            ns_resolver: NamespaceResolver::new(storage, ns_cache.unwrap_or_default()),
             prefixes,
             variables: Vec::new(),
             skip: None,

--- a/contracts/axone-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/axone-cognitarium/src/querier/plan_builder.rs
@@ -3,6 +3,7 @@ use crate::msg::{Node, TriplePattern, VarOrNamedNode, VarOrNode, VarOrNodeOrLite
 use crate::querier::expression::{Expression, Term};
 use crate::querier::mapper::{iri_as_node, literal_as_object};
 use crate::querier::plan::{PatternValue, PlanVariable, QueryNode, QueryPlan};
+use crate::querier::variable::HasBoundVariables;
 use crate::state::{
     HasCachedNamespaces, Namespace, NamespaceQuerier, NamespaceResolver, Object, Predicate, Subject,
 };

--- a/contracts/axone-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/axone-cognitarium/src/querier/plan_builder.rs
@@ -510,6 +510,7 @@ mod test {
         ];
 
         let mut deps = mock_dependencies();
+
         namespaces()
             .save(
                 deps.as_mut().storage,
@@ -530,22 +531,15 @@ mod test {
     }
 
     #[test]
-    fn build_plan() {
+    fn build_bgp() {
         let cases = vec![
             (
-                None,
-                None,
                 vec![],
-                Ok(QueryPlan {
-                    entrypoint: QueryNode::Noop {
-                        bound_variables: vec![],
-                    },
-                    variables: vec![],
+                Ok(QueryNode::Noop {
+                    bound_variables: vec![],
                 }),
             ),
             (
-                None,
-                None,
                 vec![TriplePattern {
                     subject: VarOrNode::Node(Node::NamedNode(IRI::Full(
                         "notexisting#outch".to_string(),
@@ -553,115 +547,35 @@ mod test {
                     predicate: VarOrNamedNode::Variable("predicate".to_string()),
                     object: VarOrNodeOrLiteral::Variable("object".to_string()),
                 }],
-                Ok(QueryPlan {
-                    entrypoint: QueryNode::Noop {
-                        bound_variables: vec![0usize, 1usize],
-                    },
-                    variables: vec![
-                        PlanVariable::Basic("predicate".to_string()),
-                        PlanVariable::Basic("object".to_string()),
-                    ],
+                Ok(QueryNode::Noop {
+                    bound_variables: vec![0usize, 1usize],
                 }),
             ),
             (
-                None,
-                None,
                 vec![TriplePattern {
                     subject: VarOrNode::Variable("subject".to_string()),
                     predicate: VarOrNamedNode::Variable("predicate".to_string()),
                     object: VarOrNodeOrLiteral::Variable("object".to_string()),
                 }],
-                Ok(QueryPlan {
-                    entrypoint: QueryNode::TriplePattern {
-                        subject: PatternValue::Variable(0usize),
-                        predicate: PatternValue::Variable(1usize),
-                        object: PatternValue::Variable(2usize),
-                    },
-                    variables: vec![
-                        PlanVariable::Basic("subject".to_string()),
-                        PlanVariable::Basic("predicate".to_string()),
-                        PlanVariable::Basic("object".to_string()),
-                    ],
+                Ok(QueryNode::TriplePattern {
+                    subject: PatternValue::Variable(0usize),
+                    predicate: PatternValue::Variable(1usize),
+                    object: PatternValue::Variable(2usize),
                 }),
             ),
             (
-                Some(20usize),
-                None,
                 vec![TriplePattern {
                     subject: VarOrNode::Variable("subject".to_string()),
-                    predicate: VarOrNamedNode::Variable("predicate".to_string()),
-                    object: VarOrNodeOrLiteral::Variable("object".to_string()),
+                    predicate: VarOrNamedNode::Variable("n".to_string()),
+                    object: VarOrNodeOrLiteral::Variable("n".to_string()),
                 }],
-                Ok(QueryPlan {
-                    entrypoint: QueryNode::Skip {
-                        first: 20usize,
-                        child: Box::new(QueryNode::TriplePattern {
-                            subject: PatternValue::Variable(0usize),
-                            predicate: PatternValue::Variable(1usize),
-                            object: PatternValue::Variable(2usize),
-                        }),
-                    },
-                    variables: vec![
-                        PlanVariable::Basic("subject".to_string()),
-                        PlanVariable::Basic("predicate".to_string()),
-                        PlanVariable::Basic("object".to_string()),
-                    ],
+                Ok(QueryNode::TriplePattern {
+                    subject: PatternValue::Variable(0usize),
+                    predicate: PatternValue::Variable(1usize),
+                    object: PatternValue::Variable(1usize),
                 }),
             ),
             (
-                None,
-                Some(20usize),
-                vec![TriplePattern {
-                    subject: VarOrNode::Variable("subject".to_string()),
-                    predicate: VarOrNamedNode::Variable("predicate".to_string()),
-                    object: VarOrNodeOrLiteral::Variable("object".to_string()),
-                }],
-                Ok(QueryPlan {
-                    entrypoint: QueryNode::Limit {
-                        first: 20usize,
-                        child: Box::new(QueryNode::TriplePattern {
-                            subject: PatternValue::Variable(0usize),
-                            predicate: PatternValue::Variable(1usize),
-                            object: PatternValue::Variable(2usize),
-                        }),
-                    },
-                    variables: vec![
-                        PlanVariable::Basic("subject".to_string()),
-                        PlanVariable::Basic("predicate".to_string()),
-                        PlanVariable::Basic("object".to_string()),
-                    ],
-                }),
-            ),
-            (
-                Some(20usize),
-                Some(50usize),
-                vec![TriplePattern {
-                    subject: VarOrNode::Variable("subject".to_string()),
-                    predicate: VarOrNamedNode::Variable("predicate".to_string()),
-                    object: VarOrNodeOrLiteral::Variable("object".to_string()),
-                }],
-                Ok(QueryPlan {
-                    entrypoint: QueryNode::Limit {
-                        first: 50usize,
-                        child: Box::new(QueryNode::Skip {
-                            first: 20usize,
-                            child: Box::new(QueryNode::TriplePattern {
-                                subject: PatternValue::Variable(0usize),
-                                predicate: PatternValue::Variable(1usize),
-                                object: PatternValue::Variable(2usize),
-                            }),
-                        }),
-                    },
-                    variables: vec![
-                        PlanVariable::Basic("subject".to_string()),
-                        PlanVariable::Basic("predicate".to_string()),
-                        PlanVariable::Basic("object".to_string()),
-                    ],
-                }),
-            ),
-            (
-                None,
-                None,
                 vec![
                     TriplePattern {
                         subject: VarOrNode::Variable("var1".to_string()),
@@ -679,40 +593,27 @@ mod test {
                         object: VarOrNodeOrLiteral::Node(Node::BlankNode("blank".to_string())),
                     },
                 ],
-                Ok(QueryPlan {
-                    entrypoint: QueryNode::ForLoopJoin {
-                        left: Box::new(QueryNode::CartesianProductJoin {
-                            left: Box::new(QueryNode::TriplePattern {
-                                subject: PatternValue::Variable(0usize),
-                                predicate: PatternValue::Variable(1usize),
-                                object: PatternValue::Variable(2usize),
-                            }),
-                            right: Box::new(QueryNode::TriplePattern {
-                                subject: PatternValue::Variable(3usize),
-                                predicate: PatternValue::Variable(4usize),
-                                object: PatternValue::Variable(5usize),
-                            }),
+                Ok(QueryNode::ForLoopJoin {
+                    left: Box::new(QueryNode::CartesianProductJoin {
+                        left: Box::new(QueryNode::TriplePattern {
+                            subject: PatternValue::Variable(0usize),
+                            predicate: PatternValue::Variable(1usize),
+                            object: PatternValue::Variable(2usize),
                         }),
                         right: Box::new(QueryNode::TriplePattern {
-                            subject: PatternValue::Variable(0usize),
+                            subject: PatternValue::Variable(3usize),
                             predicate: PatternValue::Variable(4usize),
-                            object: PatternValue::BlankVariable(6usize),
+                            object: PatternValue::Variable(5usize),
                         }),
-                    },
-                    variables: vec![
-                        PlanVariable::Basic("var1".to_string()),
-                        PlanVariable::Basic("var2".to_string()),
-                        PlanVariable::Basic("var3".to_string()),
-                        PlanVariable::Basic("var4".to_string()),
-                        PlanVariable::Basic("var5".to_string()),
-                        PlanVariable::Basic("var6".to_string()),
-                        PlanVariable::BlankNode("blank".to_string()),
-                    ],
+                    }),
+                    right: Box::new(QueryNode::TriplePattern {
+                        subject: PatternValue::Variable(0usize),
+                        predicate: PatternValue::Variable(4usize),
+                        object: PatternValue::BlankVariable(6usize),
+                    }),
                 }),
             ),
             (
-                None,
-                None,
                 vec![
                     TriplePattern {
                         subject: VarOrNode::Node(Node::BlankNode("1".to_string())),
@@ -725,6 +626,261 @@ mod test {
                         object: VarOrNodeOrLiteral::Variable("2".to_string()),
                     },
                 ],
+                Ok(QueryNode::ForLoopJoin {
+                    left: Box::new(QueryNode::TriplePattern {
+                        subject: PatternValue::BlankVariable(0usize),
+                        predicate: PatternValue::Variable(1usize),
+                        object: PatternValue::BlankVariable(2usize),
+                    }),
+                    right: Box::new(QueryNode::TriplePattern {
+                        subject: PatternValue::BlankVariable(0usize),
+                        predicate: PatternValue::Variable(1usize),
+                        object: PatternValue::Variable(3usize),
+                    }),
+                }),
+            ),
+        ];
+
+        let mut deps = mock_dependencies();
+        namespaces()
+            .save(
+                deps.as_mut().storage,
+                "http://axone.space/".to_string(),
+                &Namespace {
+                    value: "http://axone.space/".to_string(),
+                    key: 0u128,
+                    counter: 1u128,
+                },
+            )
+            .unwrap();
+
+        for case in cases {
+            let prefixes = &PrefixMap::default().into_inner();
+            let mut builder = PlanBuilder::new(&deps.storage, prefixes, None);
+
+            assert_eq!(builder.build_from_bgp(case.0.iter()), case.1)
+        }
+    }
+
+    #[test]
+    fn build_expression() {
+        let cases = vec![
+            (
+                msg::Expression::NamedNode(IRI::Full("http://axone.space/test".to_string())),
+                Ok(Expression::Constant(Term::String(
+                    "http://axone.space/test".to_string(),
+                ))),
+            ),
+            (
+                msg::Expression::NamedNode(IRI::Prefixed("oups:test".to_string())),
+                Err(StdError::generic_err("Prefix not found: oups")),
+            ),
+            (
+                msg::Expression::Literal(Literal::Simple("simple".to_string())),
+                Ok(Expression::Constant(Term::String("simple".to_string()))),
+            ),
+            (
+                msg::Expression::Literal(Literal::TypedValue {
+                    value: "typed".to_string(),
+                    datatype: IRI::Prefixed("oups:type".to_string()),
+                }),
+                Err(StdError::generic_err("Prefix not found: oups")),
+            ),
+            (
+                msg::Expression::Variable("variable".to_string()),
+                Ok(Expression::Variable(0usize)),
+            ),
+            (
+                msg::Expression::And(vec![msg::Expression::Variable("variable".to_string())]),
+                Ok(Expression::And(vec![Expression::Variable(0usize)])),
+            ),
+            (
+                msg::Expression::Or(vec![msg::Expression::Variable("variable".to_string())]),
+                Ok(Expression::Or(vec![Expression::Variable(0usize)])),
+            ),
+            (
+                msg::Expression::Equal(
+                    Box::new(msg::Expression::Variable("v1".to_string())),
+                    Box::new(msg::Expression::Variable("v2".to_string())),
+                ),
+                Ok(Expression::Equal(
+                    Box::new(Expression::Variable(0usize)),
+                    Box::new(Expression::Variable(1usize)),
+                )),
+            ),
+            (
+                msg::Expression::Greater(
+                    Box::new(msg::Expression::Variable("v1".to_string())),
+                    Box::new(msg::Expression::Variable("v2".to_string())),
+                ),
+                Ok(Expression::Greater(
+                    Box::new(Expression::Variable(0usize)),
+                    Box::new(Expression::Variable(1usize)),
+                )),
+            ),
+            (
+                msg::Expression::GreaterOrEqual(
+                    Box::new(msg::Expression::Variable("v1".to_string())),
+                    Box::new(msg::Expression::Variable("v2".to_string())),
+                ),
+                Ok(Expression::GreaterOrEqual(
+                    Box::new(Expression::Variable(0usize)),
+                    Box::new(Expression::Variable(1usize)),
+                )),
+            ),
+            (
+                msg::Expression::Less(
+                    Box::new(msg::Expression::Variable("v1".to_string())),
+                    Box::new(msg::Expression::Variable("v2".to_string())),
+                ),
+                Ok(Expression::Less(
+                    Box::new(Expression::Variable(0usize)),
+                    Box::new(Expression::Variable(1usize)),
+                )),
+            ),
+            (
+                msg::Expression::LessOrEqual(
+                    Box::new(msg::Expression::Variable("v1".to_string())),
+                    Box::new(msg::Expression::Variable("v2".to_string())),
+                ),
+                Ok(Expression::LessOrEqual(
+                    Box::new(Expression::Variable(0usize)),
+                    Box::new(Expression::Variable(1usize)),
+                )),
+            ),
+            (
+                msg::Expression::Not(Box::new(msg::Expression::Variable("v1".to_string()))),
+                Ok(Expression::Not(Box::new(Expression::Variable(0usize)))),
+            ),
+        ];
+
+        let deps = mock_dependencies();
+
+        for case in cases {
+            let prefixes = &PrefixMap::default().into_inner();
+            let mut builder = PlanBuilder::new(&deps.storage, prefixes, None);
+
+            assert_eq!(builder.build_expression(&case.0), case.1)
+        }
+    }
+
+    #[test]
+    fn build_plan() {
+        let cases = vec![
+            (
+                None,
+                None,
+                WhereClause::Bgp { patterns: vec![] },
+                Ok(QueryPlan {
+                    entrypoint: QueryNode::Noop {
+                        bound_variables: vec![],
+                    },
+                    variables: vec![],
+                }),
+            ),
+            (
+                Some(10usize),
+                None,
+                WhereClause::Bgp { patterns: vec![] },
+                Ok(QueryPlan {
+                    entrypoint: QueryNode::Skip {
+                        child: Box::new(QueryNode::Noop {
+                            bound_variables: vec![],
+                        }),
+                        first: 10usize,
+                    },
+                    variables: vec![],
+                }),
+            ),
+            (
+                None,
+                Some(10usize),
+                WhereClause::Bgp { patterns: vec![] },
+                Ok(QueryPlan {
+                    entrypoint: QueryNode::Limit {
+                        child: Box::new(QueryNode::Noop {
+                            bound_variables: vec![],
+                        }),
+                        first: 10usize,
+                    },
+                    variables: vec![],
+                }),
+            ),
+            (
+                Some(10usize),
+                Some(20usize),
+                WhereClause::Bgp { patterns: vec![] },
+                Ok(QueryPlan {
+                    entrypoint: QueryNode::Limit {
+                        child: Box::new(QueryNode::Skip {
+                            child: Box::new(QueryNode::Noop {
+                                bound_variables: vec![],
+                            }),
+                            first: 10usize,
+                        }),
+                        first: 20usize,
+                    },
+                    variables: vec![],
+                }),
+            ),
+            (
+                None,
+                None,
+                WhereClause::Bgp {
+                    patterns: vec![TriplePattern {
+                        subject: VarOrNode::Variable("subject".to_string()),
+                        predicate: VarOrNamedNode::Variable("predicate".to_string()),
+                        object: VarOrNodeOrLiteral::Variable("object".to_string()),
+                    }],
+                },
+                Ok(QueryPlan {
+                    entrypoint: QueryNode::TriplePattern {
+                        subject: PatternValue::Variable(0usize),
+                        predicate: PatternValue::Variable(1usize),
+                        object: PatternValue::Variable(2usize),
+                    },
+                    variables: vec![
+                        PlanVariable::Basic("subject".to_string()),
+                        PlanVariable::Basic("predicate".to_string()),
+                        PlanVariable::Basic("object".to_string()),
+                    ],
+                }),
+            ),
+            (
+                None,
+                None,
+                WhereClause::Bgp {
+                    patterns: vec![TriplePattern {
+                        subject: VarOrNode::Variable("subject".to_string()),
+                        predicate: VarOrNamedNode::Variable("n".to_string()),
+                        object: VarOrNodeOrLiteral::Variable("n".to_string()),
+                    }],
+                },
+                Ok(QueryPlan {
+                    entrypoint: QueryNode::TriplePattern {
+                        subject: PatternValue::Variable(0usize),
+                        predicate: PatternValue::Variable(1usize),
+                        object: PatternValue::Variable(1usize),
+                    },
+                    variables: vec![
+                        PlanVariable::Basic("subject".to_string()),
+                        PlanVariable::Basic("n".to_string()),
+                    ],
+                }),
+            ),
+            (
+                None,
+                None,
+                WhereClause::LateralJoin {
+                    left: Box::new(WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Node(Node::BlankNode("1".to_string())),
+                            predicate: VarOrNamedNode::Variable("n".to_string()),
+                            object: VarOrNodeOrLiteral::Node(Node::BlankNode("2".to_string())),
+                        }],
+                    }),
+                    right: Box::new(WhereClause::Bgp { patterns: vec![] }),
+                },
                 Ok(QueryPlan {
                     entrypoint: QueryNode::ForLoopJoin {
                         left: Box::new(QueryNode::TriplePattern {
@@ -732,19 +888,61 @@ mod test {
                             predicate: PatternValue::Variable(1usize),
                             object: PatternValue::BlankVariable(2usize),
                         }),
-                        right: Box::new(QueryNode::TriplePattern {
-                            subject: PatternValue::BlankVariable(0usize),
-                            predicate: PatternValue::Variable(1usize),
-                            object: PatternValue::Variable(3usize),
+                        right: Box::new(QueryNode::Noop {
+                            bound_variables: vec![],
                         }),
                     },
                     variables: vec![
                         PlanVariable::BlankNode("1".to_string()),
-                        PlanVariable::Basic("1".to_string()),
+                        PlanVariable::Basic("n".to_string()),
                         PlanVariable::BlankNode("2".to_string()),
+                    ],
+                }),
+            ),
+            (
+                None,
+                None,
+                WhereClause::Filter {
+                    inner: Box::new(WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Variable("1".to_string()),
+                            predicate: VarOrNamedNode::Variable("2".to_string()),
+                            object: VarOrNodeOrLiteral::Variable("2".to_string()),
+                        }],
+                    }),
+                    expr: msg::Expression::Variable("1".to_string()),
+                },
+                Ok(QueryPlan {
+                    entrypoint: QueryNode::Filter {
+                        inner: Box::new(QueryNode::TriplePattern {
+                            subject: PatternValue::Variable(0usize),
+                            predicate: PatternValue::Variable(1usize),
+                            object: PatternValue::Variable(1usize),
+                        }),
+                        expr: Expression::Variable(0usize),
+                    },
+                    variables: vec![
+                        PlanVariable::Basic("1".to_string()),
                         PlanVariable::Basic("2".to_string()),
                     ],
                 }),
+            ),
+            (
+                None,
+                None,
+                WhereClause::Filter {
+                    inner: Box::new(WhereClause::Bgp {
+                        patterns: vec![TriplePattern {
+                            subject: VarOrNode::Variable("1".to_string()),
+                            predicate: VarOrNamedNode::Variable("2".to_string()),
+                            object: VarOrNodeOrLiteral::Variable("2".to_string()),
+                        }],
+                    }),
+                    expr: msg::Expression::Variable("oups".to_string()),
+                },
+                Err(StdError::generic_err(
+                    "Unbound variable in filter expression",
+                )),
             ),
         ];
 
@@ -771,10 +969,7 @@ mod test {
                 builder = builder.with_limit(limit);
             }
 
-            assert_eq!(
-                builder.build_plan(&WhereClause::Bgp { patterns: case.2 }),
-                case.3
-            )
+            assert_eq!(builder.build_plan(&case.2), case.3)
         }
     }
 }

--- a/contracts/axone-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/axone-cognitarium/src/querier/plan_builder.rs
@@ -65,7 +65,10 @@ impl<'a> PlanBuilder<'a> {
     fn build_node(&mut self, where_clause: &WhereClause) -> StdResult<QueryNode> {
         match where_clause {
             WhereClause::Bgp { patterns } => self.build_from_bgp(patterns.iter()),
-            WhereClause::LateralJoin { .. } => Err(StdError::generic_err("not implemented")),
+            WhereClause::LateralJoin { left, right } => Ok(QueryNode::ForLoopJoin {
+                left: Box::new(self.build_node(left)?),
+                right: Box::new(self.build_node(right)?),
+            }),
         }
     }
 

--- a/contracts/axone-cognitarium/src/querier/variable.rs
+++ b/contracts/axone-cognitarium/src/querier/variable.rs
@@ -189,7 +189,7 @@ pub trait HasBoundVariables {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{Literal, Namespace, Node};
+    use crate::state::{InMemoryNamespaceSolver, Literal, Node};
     use cosmwasm_std::StdError;
 
     #[test]
@@ -243,29 +243,6 @@ mod tests {
                 assert_eq!(object.as_predicate(), p);
                 assert_eq!(object.as_object(), o);
             }
-        }
-    }
-
-    struct TestNamespaceSolver;
-    impl NamespaceSolver for TestNamespaceSolver {
-        fn resolve_from_key(&mut self, key: u128) -> StdResult<Namespace> {
-            match key {
-                0 => Ok(Namespace {
-                    key: 0,
-                    value: "foo".to_string(),
-                    counter: 1,
-                }),
-                1 => Ok(Namespace {
-                    key: 1,
-                    value: "bar".to_string(),
-                    counter: 1,
-                }),
-                _ => Err(StdError::not_found("Namespace")),
-            }
-        }
-
-        fn resolve_from_val(&mut self, _value: String) -> StdResult<Namespace> {
-            Err(StdError::not_found("Namespace"))
         }
     }
 
@@ -380,7 +357,7 @@ mod tests {
         ];
 
         let mut id_issuer = IdentifierIssuer::new("b", 0u128);
-        let mut ns_solver = TestNamespaceSolver;
+        let mut ns_solver = InMemoryNamespaceSolver::with(vec![(0, "foo"), (1, "bar")]);
         for (var, expected) in cases {
             assert_eq!(var.as_value(&mut ns_solver, &mut id_issuer), expected)
         }
@@ -511,7 +488,7 @@ mod tests {
             ),
         ];
 
-        let mut ns_solver = TestNamespaceSolver;
+        let mut ns_solver = InMemoryNamespaceSolver::with(vec![(0, "foo"), (1, "bar")]);
         for (var, expected) in cases {
             assert_eq!(var.as_term(&mut ns_solver), expected)
         }

--- a/contracts/axone-cognitarium/src/querier/variable.rs
+++ b/contracts/axone-cognitarium/src/querier/variable.rs
@@ -3,6 +3,7 @@ use crate::querier::expression::Term;
 use crate::state::{Literal, NamespaceSolver, Object, Predicate, Subject};
 use axone_rdf::normalize::IdentifierIssuer;
 use cosmwasm_std::StdResult;
+use std::collections::BTreeSet;
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum ResolvedVariable {
@@ -171,6 +172,18 @@ impl ResolvedVariables {
     pub fn get(&self, index: usize) -> &Option<ResolvedVariable> {
         self.variables.get(index).unwrap_or(&None)
     }
+}
+
+pub trait HasBoundVariables {
+    fn bound_variables(&self) -> BTreeSet<usize> {
+        let mut vars = BTreeSet::new();
+        self.lookup_bound_variables(&mut |v| {
+            vars.insert(v);
+        });
+        vars
+    }
+
+    fn lookup_bound_variables(&self, callback: &mut impl FnMut(usize));
 }
 
 #[cfg(test)]

--- a/contracts/axone-cognitarium/src/querier/variable.rs
+++ b/contracts/axone-cognitarium/src/querier/variable.rs
@@ -113,10 +113,10 @@ impl ResolvedVariable {
                 Object::Literal(literal) => Term::String(match literal {
                     Literal::Simple { value } => value.clone(),
                     Literal::I18NString { value, language } => {
-                        format!("{}{}", value, language).to_string()
+                        format!("{}{}", value, language)
                     }
                     Literal::Typed { value, datatype } => {
-                        format!("{}{}", value, datatype.as_iri(ns_solver)?).to_string()
+                        format!("{}{}", value, datatype.as_iri(ns_solver)?)
                     }
                 }),
             },

--- a/contracts/axone-cognitarium/src/state/mod.rs
+++ b/contracts/axone-cognitarium/src/state/mod.rs
@@ -7,3 +7,8 @@ pub use blank_nodes::*;
 pub use namespaces::*;
 pub use store::*;
 pub use triples::*;
+
+#[cfg(test)]
+mod test_util;
+#[cfg(test)]
+pub use test_util::*;

--- a/contracts/axone-cognitarium/src/state/namespaces.rs
+++ b/contracts/axone-cognitarium/src/state/namespaces.rs
@@ -218,7 +218,7 @@ impl<'a> HasCachedNamespaces for NamespaceResolver<'a> {
     }
 
     fn clear_cache(&mut self) {
-        self.ns_querier.clear_cache()
+        self.ns_querier.clear_cache();
     }
 }
 

--- a/contracts/axone-cognitarium/src/state/namespaces.rs
+++ b/contracts/axone-cognitarium/src/state/namespaces.rs
@@ -41,15 +41,15 @@ pub fn namespaces<'a>() -> IndexedMap<String, Namespace, NamespaceIndexes<'a>> {
     )
 }
 
-/// [NamespaceResolver] is a [Namespace] querying service allowing to resolve namespaces either by
+/// [NamespaceQuerier] is a [Namespace] querying service allowing to resolve namespaces either by
 /// namespace's value or namespace's internal state key. It implements a two way indexed in-memory
 /// cache to mitigate state access.
-pub struct NamespaceResolver {
+pub struct NamespaceQuerier {
     by_val: BTreeMap<String, Rc<RefCell<Namespace>>>,
     by_key: BTreeMap<u128, Rc<RefCell<Namespace>>>,
 }
 
-impl NamespaceResolver {
+impl NamespaceQuerier {
     pub fn new() -> Self {
         Self {
             by_key: BTreeMap::new(),
@@ -138,7 +138,7 @@ impl NamespaceResolver {
     }
 }
 
-impl Default for NamespaceResolver {
+impl Default for NamespaceQuerier {
     fn default() -> Self {
         Self::new()
     }
@@ -154,7 +154,7 @@ pub trait HasCachedNamespaces {
     fn clear_cache(&mut self);
 }
 
-impl HasCachedNamespaces for NamespaceResolver {
+impl HasCachedNamespaces for NamespaceQuerier {
     fn cached_namespaces(&self) -> Vec<Namespace> {
         self.by_key
             .iter()
@@ -168,9 +168,9 @@ impl HasCachedNamespaces for NamespaceResolver {
     }
 }
 
-impl From<Vec<Namespace>> for NamespaceResolver {
+impl From<Vec<Namespace>> for NamespaceQuerier {
     fn from(value: Vec<Namespace>) -> Self {
-        let mut resolver = NamespaceResolver::new();
+        let mut resolver = NamespaceQuerier::new();
         for ns in value {
             resolver.insert(ns);
         }
@@ -179,12 +179,55 @@ impl From<Vec<Namespace>> for NamespaceResolver {
     }
 }
 
+pub trait NamespaceSolver {
+    fn resolve_from_key(&mut self, key: u128) -> StdResult<Namespace>;
+    fn resolve_from_val(&mut self, value: String) -> StdResult<Namespace>;
+}
+
+pub struct NamespaceResolver<'a> {
+    storage: &'a dyn Storage,
+    ns_querier: NamespaceQuerier,
+}
+
+impl<'a> NamespaceResolver<'a> {
+    pub fn new(storage: &'a dyn Storage, ns_cache: Vec<Namespace>) -> Self {
+        Self {
+            storage,
+            ns_querier: ns_cache.into(),
+        }
+    }
+}
+
+impl<'a> NamespaceSolver for NamespaceResolver<'a> {
+    fn resolve_from_key(&mut self, key: u128) -> StdResult<Namespace> {
+        self.ns_querier
+            .resolve_from_key(self.storage, key)
+            .and_then(NamespaceQuerier::none_as_error_middleware)
+    }
+
+    fn resolve_from_val(&mut self, value: String) -> StdResult<Namespace> {
+        self.ns_querier
+            .resolve_from_val(self.storage, value)
+            .and_then(NamespaceQuerier::none_as_error_middleware)
+    }
+}
+
+impl<'a> HasCachedNamespaces for NamespaceResolver<'a> {
+    fn cached_namespaces(&self) -> Vec<Namespace> {
+        self.ns_querier.cached_namespaces()
+    }
+
+    fn clear_cache(&mut self) {
+        self.ns_querier.clear_cache()
+    }
+}
+
 /// Allow to batch write operations on [Namespace] taking care of the [NAMESPACE_KEY_INCREMENT], it
-/// manages insertions/deletions as well as counting references. It internally use a [NamespaceResolver]
+/// manages insertions/deletions as well as counting references. It internally use a [NamespaceQuerier]
 /// as a cache of new/removed/modified namespaces, to finally apply writing to the state when
 /// calling [Self::flush].
 pub struct NamespaceBatchService {
-    ns_resolver: NamespaceResolver,
+    ns_resolver: NamespaceQuerier,
     ns_key_inc: u128,
     ns_count_diff: i128,
 }
@@ -192,7 +235,7 @@ pub struct NamespaceBatchService {
 impl NamespaceBatchService {
     pub fn new(storage: &dyn Storage) -> StdResult<Self> {
         Ok(Self {
-            ns_resolver: NamespaceResolver::new(),
+            ns_resolver: NamespaceQuerier::new(),
             ns_key_inc: NAMESPACE_KEY_INCREMENT.load(storage)?,
             ns_count_diff: 0,
         })

--- a/contracts/axone-cognitarium/src/state/test_util.rs
+++ b/contracts/axone-cognitarium/src/state/test_util.rs
@@ -1,0 +1,41 @@
+use crate::state::{Namespace, NamespaceSolver};
+use cosmwasm_std::{StdError, StdResult};
+use std::collections::BTreeMap;
+
+pub struct InMemoryNamespaceSolver {
+    by_val: BTreeMap<String, Namespace>,
+    by_key: BTreeMap<u128, Namespace>,
+}
+
+impl InMemoryNamespaceSolver {
+    pub fn with(namespaces: Vec<(u128, &str)>) -> Self {
+        let mut by_val = BTreeMap::new();
+        let mut by_key = BTreeMap::new();
+        for (key, value) in namespaces {
+            let ns = Namespace {
+                value: value.to_string(),
+                key,
+                counter: 1,
+            };
+            by_val.insert(value.to_string(), ns.clone());
+            by_key.insert(key, ns);
+        }
+        Self { by_val, by_key }
+    }
+}
+
+impl NamespaceSolver for InMemoryNamespaceSolver {
+    fn resolve_from_key(&mut self, key: u128) -> StdResult<Namespace> {
+        self.by_key
+            .get(&key)
+            .ok_or_else(|| StdError::not_found("Namespace"))
+            .cloned()
+    }
+
+    fn resolve_from_val(&mut self, _value: String) -> StdResult<Namespace> {
+        self.by_val
+            .get(&_value)
+            .ok_or_else(|| StdError::not_found("Namespace"))
+            .cloned()
+    }
+}

--- a/contracts/axone-cognitarium/src/state/triples.rs
+++ b/contracts/axone-cognitarium/src/state/triples.rs
@@ -1,3 +1,4 @@
+use crate::state::NamespaceSolver;
 use blake3::Hash;
 use cosmwasm_std::StdResult;
 use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex};
@@ -150,11 +151,8 @@ impl Node {
         key
     }
 
-    pub fn as_iri<F>(&self, ns_fn: &mut F) -> StdResult<String>
-    where
-        F: FnMut(u128) -> StdResult<String>,
-    {
-        Ok(ns_fn(self.namespace)? + &self.value)
+    pub fn as_iri(&self, ns_solver: &mut dyn NamespaceSolver) -> StdResult<String> {
+        Ok(ns_solver.resolve_from_key(self.namespace)?.value + &self.value)
     }
 }
 

--- a/contracts/axone-dataverse/src/contract.rs
+++ b/contracts/axone-dataverse/src/contract.rs
@@ -142,9 +142,8 @@ mod tests {
     };
     use crate::testutil::testutil::read_test_data;
     use axone_cognitarium::msg::{
-        DataFormat, Head, Node, Results, SelectItem, SelectQuery, SelectResponse,
-        SimpleWhereCondition, TriplePattern, Value, VarOrNamedNode, VarOrNode, VarOrNodeOrLiteral,
-        WhereCondition, IRI,
+        DataFormat, Head, Node, Results, SelectItem, SelectQuery, SelectResponse, TriplePattern,
+        Value, VarOrNamedNode, VarOrNode, VarOrNodeOrLiteral, WhereClause, IRI,
     };
     use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
     use cosmwasm_std::{
@@ -304,15 +303,15 @@ mod tests {
                             prefixes: vec![],
                             limit: Some(1u32),
                             select: vec![SelectItem::Variable("p".to_string())],
-                            r#where: vec![WhereCondition::Simple(
-                                SimpleWhereCondition::TriplePattern(TriplePattern {
+                            r#where: WhereClause::Bgp {
+                                patterns: vec![TriplePattern {
                                     subject: VarOrNode::Node(Node::NamedNode(IRI::Full(
                                         "http://example.edu/credentials/3732".to_string(),
                                     ))),
                                     predicate: VarOrNamedNode::Variable("p".to_string()),
                                     object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                                })
-                            )],
+                                }]
+                            },
                         }
                     })
                 );

--- a/contracts/axone-dataverse/src/registrar/registry.rs
+++ b/contracts/axone-dataverse/src/registrar/registry.rs
@@ -2,8 +2,8 @@ use crate::registrar::credential::DataverseCredential;
 use crate::state::DATAVERSE;
 use crate::ContractError;
 use axone_cognitarium::msg::{
-    DataFormat, Node, SelectItem, SelectQuery, SimpleWhereCondition, TriplePattern, VarOrNamedNode,
-    VarOrNode, VarOrNodeOrLiteral, WhereCondition, IRI,
+    DataFormat, Node, SelectItem, SelectQuery, TriplePattern, VarOrNamedNode, VarOrNode,
+    VarOrNodeOrLiteral, WhereClause, IRI,
 };
 use axone_cognitarium_client::CognitariumClient;
 use cosmwasm_std::{DepsMut, StdResult, Storage, WasmMsg};
@@ -36,15 +36,15 @@ impl ClaimRegistrar {
                 prefixes: vec![],
                 limit: Some(1u32),
                 select: vec![SelectItem::Variable("p".to_string())],
-                r#where: vec![WhereCondition::Simple(SimpleWhereCondition::TriplePattern(
-                    TriplePattern {
+                r#where: WhereClause::Bgp {
+                    patterns: vec![TriplePattern {
                         subject: VarOrNode::Node(Node::NamedNode(IRI::Full(
                             credential.id.to_string(),
                         ))),
                         predicate: VarOrNamedNode::Variable("p".to_string()),
                         object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                    },
-                ))],
+                    }],
+                },
             },
         )?;
 


### PR DESCRIPTION
Closes #614 

## Description

Here is an API evolution to integrate expression filtering capabilities in the cognitarium querying mechanism. The changes are breaking.

The idea is to enhance the `WhereClause` type by renaming the old `Simple` by `Bgp` for basic graph patterns and adding a new `Filter` clause allowing to filter another clause based on expressions, this would allow to filter with specific variable values.

Here is an example using this to filter on a range of a `height` value:
```json
{
    "filter": {
        "expr": {
            "and": [
                {
                    "greater_or_equal": [
                        {"variable": "height"},
                        {"literal": "1000"}
                    ]
                },
                {
                    "less_or_equal": [
                        {"variable": "height"},
                        {"literal": "2000"}
                    ]
                }
            ]
        },
        "inner": {
            "bgp": [
                {
                    "subject": {"variable": "subject"},
                    "predicate": {"named": {"full": "height"}},
                    "object": {"variable": "height"}
                }
            ]
        }
    }
}
```

In this example the BGP will provide the resolution of the `height` variable and the filter will then limit the possibilities for those between 1000 and 2000.

_@ccamel @bdeneux I'd appreciate your insights on this design before going further in the implementation :)_

## Details

The `WhereClause::Filter` takes an inner clause and filtering matching the provided `Expression`. An expression internally resolves as a term, which can currently be either a `String` or a `bool`. A term can be built from a variable so it can be constructed from object literals for example, the construction of the resulting string is opinionated and impact the behaviour of comparison operators, so I'll let you juge the proposed implementation.

This implementation is very simplistic, it'd make sense in the future to provide more types of `Term` for a fine grained control on expression operators...

## Misc

A `WhereClause::LateralJoin` clause has also been added to allow to join two clauses as a for loop, this was needed to make the `Describe` message to work with the refactoring.

The namespace resolution mechanism has been reworked by providing trait abstraction to ease tests and integration with the new filtering capabilities, it brings a lot of additional changes sorry for that..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced query flexibility by allowing optional `WhereClause` in query operations.
	- Introduced a new `Expression` type for complex logical operations in queries.
	- Added `Filter` variant in query plans to enable conditional filtering of results.

- **Bug Fixes**
	- Improved error handling when no valid `WhereClause` is provided.

- **Documentation**
	- Updated documentation to reflect changes in query structures, including `WhereClause`, `Bgp`, and `Expression`.
	- Clarified the usage of deletion conditions and query parameters.

- **Chores**
	- Refactored internal logic for namespace resolution and query engine operations for better clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->