### PR TITLE
feat(dataverse)!: rework and enhance vc stored context

### DIFF
--- a/contracts/axone-dataverse/src/registrar/rdf.rs
+++ b/contracts/axone-dataverse/src/registrar/rdf.rs
@@ -8,36 +8,48 @@ use cosmwasm_std::{Binary, StdError};
 use rio_api::model::{BlankNode, Literal, NamedNode, Subject, Term, Triple};
 
 pub const VC_RESERVED_PREDICATES: &[NamedNode<'_>] = &[
-    VC_SUBMITTER_ADDRESS,
-    VC_TYPE,
-    VC_ISSUER,
-    VC_VALID_FROM,
-    VC_VALID_UNTIL,
-    VC_SUBJECT,
-    VC_CLAIM,
+    VC_HEADER_HEIGHT,
+    VC_HEADER_TIMESTAMP,
+    VC_HEADER_TX,
+    VC_HEADER_SENDER,
+    VC_BODY_TYPE,
+    VC_BODY_ISSUER,
+    VC_BODY_VALID_FROM,
+    VC_BODY_VALID_UNTIL,
+    VC_BODY_SUBJECT,
+    VC_BODY_CLAIM,
     VC_CLAIM_ORIGINAL_NODE,
 ];
 
-pub const VC_SUBMITTER_ADDRESS: NamedNode<'_> = NamedNode {
-    iri: "dataverse:credential#submitterAddress",
+pub const VC_HEADER_HEIGHT: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential:header#height",
 };
-pub const VC_TYPE: NamedNode<'_> = NamedNode {
-    iri: "dataverse:credential#type",
+pub const VC_HEADER_TIMESTAMP: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential:header#timestamp",
 };
-pub const VC_ISSUER: NamedNode<'_> = NamedNode {
-    iri: "dataverse:credential#issuer",
+pub const VC_HEADER_TX: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential:header#tx_index",
 };
-pub const VC_VALID_FROM: NamedNode<'_> = NamedNode {
-    iri: "dataverse:credential#validFrom",
+pub const VC_HEADER_SENDER: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential:header#sender",
 };
-pub const VC_VALID_UNTIL: NamedNode<'_> = NamedNode {
-    iri: "dataverse:credential#validUntil",
+pub const VC_BODY_TYPE: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential:body#type",
 };
-pub const VC_SUBJECT: NamedNode<'_> = NamedNode {
-    iri: "dataverse:credential#subject",
+pub const VC_BODY_ISSUER: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential:body#issuer",
 };
-pub const VC_CLAIM: NamedNode<'_> = NamedNode {
-    iri: "dataverse:credential#claim",
+pub const VC_BODY_VALID_FROM: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential:body#validFrom",
+};
+pub const VC_BODY_VALID_UNTIL: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential:body#validUntil",
+};
+pub const VC_BODY_SUBJECT: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential:body#subject",
+};
+pub const VC_BODY_CLAIM: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential:body#claim",
 };
 
 /// Used when a claim triple contains a named node as object to establish a hierarchy, we replace this hierarchical link
@@ -85,24 +97,38 @@ impl<'a> DataverseCredential<'a> {
         let mut triples = vec![
             Triple {
                 subject: c_subject,
-                predicate: VC_SUBMITTER_ADDRESS,
+                predicate: VC_HEADER_HEIGHT,
                 object: Term::Literal(Literal::Simple {
-                    value: self.submitter_addr.as_str(),
+                    value: &self.height,
                 }),
             },
             Triple {
                 subject: c_subject,
-                predicate: VC_ISSUER,
+                predicate: VC_HEADER_TIMESTAMP,
+                object: Term::Literal(Literal::Simple {
+                    value: &self.timestamp,
+                }),
+            },
+            Triple {
+                subject: c_subject,
+                predicate: VC_HEADER_SENDER,
+                object: Term::Literal(Literal::Simple {
+                    value: self.sender.as_str(),
+                }),
+            },
+            Triple {
+                subject: c_subject,
+                predicate: VC_BODY_ISSUER,
                 object: Term::NamedNode(NamedNode { iri: self.issuer }),
             },
             Triple {
                 subject: c_subject,
-                predicate: VC_TYPE,
+                predicate: VC_BODY_TYPE,
                 object: Term::NamedNode(NamedNode { iri: self.r#type }),
             },
             Triple {
                 subject: c_subject,
-                predicate: VC_VALID_FROM,
+                predicate: VC_BODY_VALID_FROM,
                 object: Term::Literal(Literal::Typed {
                     value: self.valid_from,
                     datatype: RDF_DATE_TYPE,
@@ -110,17 +136,25 @@ impl<'a> DataverseCredential<'a> {
             },
             Triple {
                 subject: c_subject,
-                predicate: VC_SUBJECT,
+                predicate: VC_BODY_SUBJECT,
                 object: Term::NamedNode(NamedNode { iri: self.claim.id }),
             },
         ];
+
+        if let Some(tx_index) = &self.tx_index {
+            triples.push(Triple {
+                subject: c_subject,
+                predicate: VC_HEADER_TX,
+                object: Term::Literal(Literal::Simple { value: tx_index }),
+            });
+        }
 
         triples.extend(self.claim_as_triples(claim_node, named_issuer, blank_issuer)?);
 
         if let Some(valid_until) = self.valid_until {
             triples.push(Triple {
                 subject: c_subject,
-                predicate: VC_VALID_UNTIL,
+                predicate: VC_BODY_VALID_UNTIL,
                 object: Term::Literal(Literal::Typed {
                     value: valid_until,
                     datatype: RDF_DATE_TYPE,
@@ -219,7 +253,7 @@ impl<'a> DataverseCredential<'a> {
 
         triples.push(Triple {
             subject: Subject::NamedNode(NamedNode { iri: self.id }),
-            predicate: VC_CLAIM,
+            predicate: VC_BODY_CLAIM,
             object: Term::BlankNode(claim_node),
         });
 
@@ -241,28 +275,32 @@ mod test {
     use crate::credential::vc::VerifiableCredential;
     use crate::testutil::testutil;
     use axone_rdf::dataset::Dataset;
-    use cosmwasm_std::Addr;
+    use cosmwasm_std::testing::message_info;
+    use testing::addr::{addr, SENDER};
+    use testing::mock::mock_env_addr;
 
     #[test]
     fn proper_serialization() {
         let owned_quads = testutil::read_test_quads("vc-valid.nq");
         let dataset = Dataset::from(owned_quads.as_slice());
         let vc = VerifiableCredential::try_from(&dataset).unwrap();
-        let dc = DataverseCredential::try_from((
-            Addr::unchecked("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0"),
-            &vc,
-        ))
-        .unwrap();
+        let dc =
+            DataverseCredential::try_from((mock_env_addr(), message_info(&addr(SENDER), &[]), &vc))
+                .unwrap();
 
-        let expected = "<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#submitterAddress> \"axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0\" .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#type> <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#validFrom> \"2024-01-22T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#subject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+        let expected = r#"<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#height> "12345" .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#timestamp> "1571797419" .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#sender> "cosmwasm1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qlm3aqg" .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#type> <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#validFrom> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#subject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#tx_index> "3" .
 _:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/axone/ontology/vnext/thesaurus/digital-service-category/Storage> .
-_:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasTag> \"Cloud\" .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#claim> _:c0 .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#validUntil> \"2025-01-22T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n";
+_:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#claim> _:c0 .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#validUntil> "2025-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+"#;
 
         let serialization_res = dc.serialize(DataFormat::NQuads);
         assert!(serialization_res.is_ok());
@@ -278,24 +316,26 @@ _:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/de
         let owned_quads = testutil::read_test_quads("vc-claim-hierarchy.nq");
         let dataset = Dataset::from(owned_quads.as_slice());
         let vc = VerifiableCredential::try_from(&dataset).unwrap();
-        let dc = DataverseCredential::try_from((
-            Addr::unchecked("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0"),
-            &vc,
-        ))
-        .unwrap();
+        let dc =
+            DataverseCredential::try_from((mock_env_addr(), message_info(&addr(SENDER), &[]), &vc))
+                .unwrap();
 
-        let expected = "<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#submitterAddress> \"axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0\" .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#type> <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#validFrom> \"2024-01-22T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#subject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+        let expected = r#"<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#height> "12345" .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#timestamp> "1571797419" .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#sender> "cosmwasm1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qlm3aqg" .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#type> <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#validFrom> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#subject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#tx_index> "3" .
 _:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/axone/ontology/vnext/thesaurus/digital-service-category/Storage> .
-_:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasTag> \"Cloud\" .
+_:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
 _:c0 <test:claim#named-hierarchy> _:a0 .
-_:a0 <test:claim#nested-predicate> \"nested value\" .
+_:a0 <test:claim#nested-predicate> "nested value" .
 _:a0 <dataverse:claim#original-node> <test:named-link> .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#claim> _:c0 .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#validUntil> \"2025-01-22T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n";
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#claim> _:c0 .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#validUntil> "2025-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+"#;
 
         let serialization_res = dc.serialize(DataFormat::NQuads);
         assert!(serialization_res.is_ok());
@@ -311,11 +351,9 @@ _:a0 <dataverse:claim#original-node> <test:named-link> .
         let owned_quads = testutil::read_test_quads("vc-unsupported-4.nq");
         let dataset = Dataset::from(owned_quads.as_slice());
         let vc = VerifiableCredential::try_from(&dataset).unwrap();
-        let dc = DataverseCredential::try_from((
-            Addr::unchecked("axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0"),
-            &vc,
-        ))
-        .unwrap();
+        let dc =
+            DataverseCredential::try_from((mock_env_addr(), message_info(&addr(SENDER), &[]), &vc))
+                .unwrap();
 
         let res = dc.serialize(DataFormat::NQuads);
         assert!(res.is_err());

--- a/contracts/axone-dataverse/testdata/vc-unsupported-4.nq
+++ b/contracts/axone-dataverse/testdata/vc-unsupported-4.nq
@@ -1,6 +1,6 @@
 <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/axone/ontology/vnext/thesaurus/digital-service-category/Storage> .
 <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
-<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <dataverse:credential#claim> "this shall not be allowed" .
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <dataverse:credential:body#claim> "this shall not be allowed" .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .


### PR DESCRIPTION
Closes #615 

## Details

Brings the changes proposed in #615 by making the difference between VC's body and context (i.e. considered as headers in the RDF), and enhance this context with block information (i.e. `height`, `timestamp` & `tx_index`).

Those changes are considered breaking as it breaks the model stored in the cognitarium.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced claims processing by integrating environmental context into contract execution.
  - Updated `DataverseCredential` structure to include new fields for better context representation.

- **Bug Fixes**
  - Improved logic for handling credential attributes, ensuring accuracy in data representation.

- **Documentation**
  - Updated test cases to reflect changes in credential structure and logic adjustments.

- **Refactor**
  - Restructured NamedNode constants for clarity and improved semantic organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->