### PR TITLE
Ci/notify discussions release

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -5,22 +5,6 @@ on:
     types: [published]
 
 jobs:
-  notify-discord:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Notify Discord
-        uses: fjogeleit/http-request-action@v1
-        with:
-          url: ${{ secrets.DISCORD_WEBHOOK }}
-          method: "POST"
-          customHeaders: '{"Content-Type": "application/json"}'
-          data: |-
-            {
-              "avatar_url": "https://avatars.githubusercontent.com/u/98603954?v=4",
-              "username": "Bot Anik",
-              "content": "🚨 A new version of @${{ github.repository }} ${{ github.event.release.tag_name }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\n👉 Official repo: https://github.com/${{ github.repository }}"
-            }
-
   notify-github-discussion:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -4,26 +4,81 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (leave empty for last one)"
+
 jobs:
+  set-env:
+    runs-on: ubuntu-22.04
+    outputs:
+      tag: ${{ steps.set-env.outputs.tag }}
+      repo_name: ${{ steps.set-env.outputs.repo_name }}
+    steps:
+      - name: Expose tag and repo_name
+        id: set-env
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG=$(gh release view --json tagName -q '.tagName')
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+          REPO_NAME=${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}
+          echo "repo_name=$REPO_NAME" >> $GITHUB_OUTPUT
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+
   notify-github-discussion:
     runs-on: ubuntu-22.04
+    needs: set-env
     steps:
-      - name: Post announcement to GitHub Discussion
-        uses: abirismyname/create-discussion@v1
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Extract changelog for tag
+        run: |
+          {
+            echo 'CHANGELOG<<EOF'
+            gh release view ${{ needs.set-env.outputs.tag }} --json body -q '.body'
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.OPS_TOKEN }}
-        with:
-          title: "🎉 ${{ github.repository }} ${{ github.event.release.tag_name }} has been released"
-          body: |
-            🎉 [${{ github.repository }}](https://github.com/${{ github.repository }}) ${{ github.event.release.tag_name }} has been released!
 
-            👉 Changelog: <https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}>
-            👉 Official repo: <https://github.com/${{ github.repository }}>
-          repository-id: "R_kgDOLsWt6A"
-          category-id: "DIC_kwDOLsWt6M4CemGO"
+      - name: Create an announcement discussion for release
+        uses: abirismyname/create-discussion@v1.2.0
+        with:
+          title: 🎉 ${{ needs.set-env.outputs.repo_name }} ${{ needs.set-env.outputs.tag }} released!
+          body: |
+            Hey frens! [${{ github.repository }}](https://github.com/${{ github.repository }}) `${{ needs.set-env.outputs.tag }}` just dropped! 🚀
+
+            Some fresh updates are here. Dive into the changelog and see what's cooking! 🔥
+
+            # Changelog
+
+            ${{ env.CHANGELOG }}
+
+            # Resources
+
+            📄 Changelog: <https://github.com/${{ github.repository }}/releases/tag/${{ needs.set-env.outputs.tag }}>
+            🛠️ Official repo: <https://github.com/${{ github.repository }}>
+            💬 Vibe with us on Discord: <${{ env.DISCORD_URL }}>
+            🐦 Catch us on 𝕏: <${{ env.TWITTER_URL }}>
+          repository-id: ${{ env.REPOSITORY_ID }}
+          category-id: ${{ env.CATEGORY_ID }}
+        env:
+          GH_TOKEN: ${{ secrets.OPS_TOKEN }}
+          DISCORD_URL: ${{ vars.DISCORD_URL }}
+          TWITTER_URL: ${{ vars.TWITTER_URL }}
+          REPOSITORY_ID: ${{ vars.DISCUSSIONS_REPOSITORY_ID }}
+          CATEGORY_ID: ${{ vars.DISCUSSIONS_CATEGORY_ID }}
 
   update-docs:
     runs-on: ubuntu-22.04
+    if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Update docs repository
         uses: fjogeleit/http-request-action@v1
@@ -45,6 +100,7 @@ jobs:
 
   update-schema:
     runs-on: ubuntu-22.04
+    if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Update schema repository
         uses: fjogeleit/http-request-action@v1


### PR DESCRIPTION
Addresses https://github.com/axone-protocol/community/issues/6.

- Additionally, removes Discord notifications on release, as [GitHub Discussions](https://github.com/orgs/axone-protocol/discussions) will now serve as the primary release notification channel, with optional forwarding to Discord if needed.
- Also enables manual triggering with a specific tag input (only for the notification of release on discussions), alongside the default trigger on release. This adds flexibility for replaying the workflow when necessary.​


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a manual trigger for workflows with an optional input parameter for tagging.
	- Added a new job to set environment variables, improving workflow clarity.
	- Enhanced messaging format for notifications related to GitHub discussions.

- **Improvements**
	- Updated logic for retrieving the latest release tag.
	- Restructured jobs to ensure efficient execution based on specific events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->