### PR TITLE
Feat/unverified credentials issuer sender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "axone-cognitarium-client",
  "axone-rdf",
  "base64 0.22.1",
+ "bech32 0.11.0",
  "bs58",
  "cosmwasm-schema",
  "cosmwasm-std 2.1.5",
@@ -281,6 +282,7 @@ dependencies = [
  "multibase",
  "rio_api",
  "rio_turtle",
+ "ripemd",
  "schemars",
  "serde",
  "sha2 0.10.8",
@@ -2243,6 +2245,15 @@ dependencies = [
  "oxiri",
  "quick-xml",
  "rio_api",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/contracts/axone-dataverse/Cargo.toml
+++ b/contracts/axone-dataverse/Cargo.toml
@@ -37,6 +37,7 @@ serde.workspace = true
 sha2 = "0.10.8"
 thiserror.workspace = true
 unsigned-varint = "0.8.0"
+bech32 = "0.11.0"
 
 [dev-dependencies]
 base64 = "0.22.1"

--- a/contracts/axone-dataverse/Cargo.toml
+++ b/contracts/axone-dataverse/Cargo.toml
@@ -21,6 +21,7 @@ axone-cognitarium.workspace = true
 axone-cognitarium-client.workspace = true
 axone-rdf.workspace = true
 base64 = "0.22.1"
+bech32 = "0.11.0"
 bs58 = "0.5.1"
 cosmwasm-schema.workspace = true
 cosmwasm-std.workspace = true
@@ -32,12 +33,12 @@ itertools = "0.13.0"
 multibase = "0.9.1"
 rio_api.workspace = true
 rio_turtle.workspace = true
+ripemd = "0.1.3"
 schemars.workspace = true
 serde.workspace = true
 sha2 = "0.10.8"
 thiserror.workspace = true
 unsigned-varint = "0.8.0"
-bech32 = "0.11.0"
 
 [dev-dependencies]
 base64 = "0.22.1"

--- a/contracts/axone-dataverse/src/credential/vc.rs
+++ b/contracts/axone-dataverse/src/credential/vc.rs
@@ -410,6 +410,66 @@ mod test {
     }
 
     #[test]
+    fn is_issued_by() {
+        struct TC<'a> {
+            issuer: &'a str,
+            addr: Addr,
+            expected: bool,
+        }
+        let cases = vec![
+            TC {
+                issuer: "did:key:zQ3shsoarhrw7SoyUyoCbwv8k2BRRLeqkjRkffGqx7WNpMQgw",
+                addr: Addr::unchecked("axone178mjppxcf3n9q3q7utdwrajdal0tsqvymz0900"),
+                expected: true,
+            },
+            TC {
+                issuer: "did:key:z6MkvMXwgwJTJacfBGk5fxr3d4k3uzh4eHTi3oFagNyK55Tt",
+                addr: Addr::unchecked("axone1el0ln38j0qvkr22pwztelv3hxrsc0gx5zjsfky"),
+                expected: true,
+            },
+            TC {
+                issuer: "did:key:zQ3shsoarhrw7SoyUyoCbwv8k2BRRLeqkjRkffGqx7WNpMQgw",
+                addr: Addr::unchecked("axone1hg3htshrh9xnhrmwrxnfnu0dtlx6345lu2c09f"),
+                expected: false,
+            },
+            TC {
+                issuer: "did:foo:zQ3shsoarhrw7SoyUyoCbwv8k2BRRLeqkjRkffGqx7WNpMQgw",
+                addr: Addr::unchecked("axone178mjppxcf3n9q3q7utdwrajdal0tsqvymz0900"),
+                expected: false,
+            },
+            TC {
+                issuer: "did:key:foo",
+                addr: Addr::unchecked("axone178mjppxcf3n9q3q7utdwrajdal0tsqvymz0900"),
+                expected: false,
+            },
+            TC {
+                issuer: "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQgQjQC23ZCit6F",
+                addr: Addr::unchecked("axone178mjppxcf3n9q3q7utdwrajdal0tsqvymz0900"),
+                expected: false,
+            },
+            TC {
+                issuer: "did:key:z6MkvMXwgwJTJacfB",
+                addr: Addr::unchecked("axone1el0ln38j0qvkr22pwztelv3hxrsc0gx5zjsfky"),
+                expected: false,
+            },
+            TC {
+                issuer: "did:key:zQ3shsoarhrw7SoyUyoCbwv8k2BRRLeqkjRkffGqx7WNpMQgw",
+                addr: Addr::unchecked("178mjppxcf3n9q3q7utdwrajdal0tsqvymz0900"),
+                expected: false,
+            },
+        ];
+        for tc in cases {
+            let owned_quads = testutil::read_test_quads("vc-eddsa-2020-ok-unsecured.nq");
+            let dataset = Dataset::from(owned_quads.as_slice());
+
+            let mut vc_res = VerifiableCredential::try_from(&dataset).expect("vc from dataset");
+            vc_res.issuer = tc.issuer;
+
+            assert_eq!(vc_res.is_issued_by(&tc.addr), tc.expected);
+        }
+    }
+
+    #[test]
     fn vc_verify() {
         let cases = vec![
             "vc-eddsa-2018-ok.nq",

--- a/contracts/axone-dataverse/src/msg.rs
+++ b/contracts/axone-dataverse/src/msg.rs
@@ -41,7 +41,9 @@ pub enum ExecuteMsg {
     ///
     ///   2. **Unique Identifier Mandate**: Each Verifiable Credential within the dataverse must possess a unique identifier.
     ///
-    ///   3. **Issuer Signature**: Claims must bear the issuer's signature. This signature must be verifiable, ensuring authenticity and credibility.
+    ///   3. **Issuer Verification**: Claims are accepted if they either:
+    ///      - Bear a verifiable issuer's signature to ensure authenticity.
+    ///      - Originate from the transaction sender, in which case the transaction signature serves as proof of authenticity.
     ///
     ///   4. **Content**: The actual implementation supports the submission of a single Verifiable Credential, containing a single claim.
     ///

--- a/contracts/axone-dataverse/testdata/vc-eddsa-2020-ok-unsecured-trusted.nq
+++ b/contracts/axone-dataverse/testdata/vc-eddsa-2020-ok-unsecured-trusted.nq
@@ -1,0 +1,9 @@
+<did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw> <https://example.org/examples#degree> _:b2 .
+<http://example.edu/credentials/3732> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#UniversityDegreeCredential> .
+<http://example.edu/credentials/3732> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#expirationDate> "2026-02-16T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#issuanceDate> "2024-02-16T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#issuer> <did:key:zQ3shsoarhrw7SoyUyoCbwv8k2BRRLeqkjRkffGqx7WNpMQgw> .
+_:b2 <http://schema.org/name> "Bachelor of Science and Arts"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#BachelorDegree> .

--- a/docs/axone-dataverse.md
+++ b/docs/axone-dataverse.md
@@ -82,7 +82,7 @@ To maintain integrity and coherence in the dataverse, several preconditions are 
 
 2. **Unique Identifier Mandate**: Each Verifiable Credential within the dataverse must possess a unique identifier.
 
-3. **Issuer Signature**: Claims must bear the issuer's signature. This signature must be verifiable, ensuring authenticity and credibility.
+3. **Issuer Verification**: Claims are accepted if they either: - Bear a verifiable issuer's signature to ensure authenticity. - Originate from the transaction sender, in which case the transaction signature serves as proof of authenticity.
 
 4. **Content**: The actual implementation supports the submission of a single Verifiable Credential, containing a single claim.
 
@@ -238,5 +238,5 @@ let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-dataverse.json` (`13c4a7b5af578887`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-dataverse.json` (`2d209bff84484c1c`)*
 ````


### PR DESCRIPTION
This PR enhances the submission process for claims to the chain by introducing support for _unverified_ credentials. Previously, only [VCs](https://en.wikipedia.org/wiki/Verifiable_credentials) with a valid issuer signature were accepted. Now, the system allows VCs without an issuer’s signature if the issuer matches the transaction _sender_. In such cases, the transaction signature serves as proof of integrity.

_Rationale:_

This improvement reduces friction for scenarios where the issuer and registrant are the same, making submissions to the chain simpler and more efficient. Additionally, it extends the flexibility of the system to accommodate DAOs and smart contracts acting as issuers, enhancing their ability to participate in the dataverse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new dependencies for enhanced functionality: `bech32` and `ripemd`.
	- Introduced a method to verify if a credential is issued by a specified address.
	- Enhanced claims submission logic to allow claims from the transaction sender without a separate issuer's signature.

- **Bug Fixes**
	- Improved error handling for claims submission process.

- **Documentation**
	- Updated documentation for `ExecuteMsg::SubmitClaims` to reflect new conditions for claims submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->