### PR TITLE
ci(workflow): restrict crate publication trigger to new releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: publish-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   publish-crates:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish
 
 on:
-  push:
-    branches: [main]
-    tags: ["v*"]
+  release:
+    types: [published]
 
 concurrency:
   group: publish-${{ github.ref }}


### PR DESCRIPTION
Self explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration to trigger on published release events instead of push events.
	- Modified concurrency settings to allow jobs to run concurrently without canceling in-progress jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->