### PR TITLE
build(project): use DIR_WASM env variable for wasm check target path

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -94,7 +94,7 @@ workspace = true
 [tasks.check-contracts]
 dependencies = ["install-cosmwasm-check", "wasm"]
 script = '''
-cosmwasm-check ./target/wasm32-unknown-unknown/release/*.wasm
+cosmwasm-check ${DIR_WASM}/*.wasm
 '''
 
 [tasks.docs-clean]


### PR DESCRIPTION
Self explantory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the configuration for asset verification to use a dynamic path for compiled files, offering enhanced flexibility in managing file locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->