### PR TITLE
Refactor/specify rdf types

### DIFF
--- a/contracts/axone-cognitarium/src/querier/engine.rs
+++ b/contracts/axone-cognitarium/src/querier/engine.rs
@@ -36,7 +36,7 @@ impl<'a> QueryEngine<'a> {
         &'a self,
         plan: QueryPlan,
         selection: Vec<SelectItem>,
-    ) -> StdResult<SelectResults<'_>> {
+    ) -> StdResult<SelectResults<'a>> {
         let bindings = selection
             .iter()
             .map(|item| match item {
@@ -63,7 +63,7 @@ impl<'a> QueryEngine<'a> {
         plan: QueryPlan,
         prefixes: &HashMap<String, String>,
         templates: Vec<(VarOrNode, VarOrNamedNode, VarOrNodeOrLiteral)>,
-    ) -> StdResult<ResolvedAtomIterator<'_>> {
+    ) -> StdResult<ResolvedAtomIterator<'a>> {
         let templates = templates
             .into_iter()
             .map(|t| AtomTemplate::try_new(&plan, prefixes, t))
@@ -82,7 +82,7 @@ impl<'a> QueryEngine<'a> {
         &'a self,
         plan: QueryPlan,
         templates: Vec<TripleTemplate>,
-    ) -> ResolvedTripleIterator<'_> {
+    ) -> ResolvedTripleIterator<'a> {
         ResolvedTripleIterator::new(self.eval_plan(plan), templates)
     }
 
@@ -106,7 +106,7 @@ impl<'a> QueryEngine<'a> {
         }
     }
 
-    pub fn eval_plan(&'a self, plan: QueryPlan) -> ResolvedVariablesIterator<'_> {
+    pub fn eval_plan(&'a self, plan: QueryPlan) -> ResolvedVariablesIterator<'a> {
         return self.eval_node(plan.entrypoint)(ResolvedVariables::with_capacity(
             plan.variables.len(),
         ));

--- a/contracts/axone-dataverse/src/contract.rs
+++ b/contracts/axone-dataverse/src/contract.rs
@@ -382,14 +382,14 @@ mod tests {
             ]
         );
 
-        let expected_data = r#"<http://example.edu/credentials/3732> <dataverse:credential:header#height> "12345" .
-<http://example.edu/credentials/3732> <dataverse:credential:header#timestamp> "1571797419" .
+        let expected_data = r#"<http://example.edu/credentials/3732> <dataverse:credential:header#height> "12345"^^<http://www.w3.org/2001/XMLSchema#unsignedLong> .
+<http://example.edu/credentials/3732> <dataverse:credential:header#timestamp> "1571797419"^^<http://www.w3.org/2001/XMLSchema#unsignedLong> .
 <http://example.edu/credentials/3732> <dataverse:credential:header#sender> "axone1072nc6egexqr2v6vpp7yxwm68plvqnkf5uemr0" .
 <http://example.edu/credentials/3732> <dataverse:credential:body#issuer> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
 <http://example.edu/credentials/3732> <dataverse:credential:body#type> <https://example.org/examples#UniversityDegreeCredential> .
 <http://example.edu/credentials/3732> <dataverse:credential:body#validFrom> "2024-02-16T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
 <http://example.edu/credentials/3732> <dataverse:credential:body#subject> <did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw> .
-<http://example.edu/credentials/3732> <dataverse:credential:header#tx_index> "3" .
+<http://example.edu/credentials/3732> <dataverse:credential:header#tx_index> "3"^^<http://www.w3.org/2001/XMLSchema#unsignedInt> .
 _:c0 <https://example.org/examples#degree> _:b0 .
 _:b0 <http://schema.org/name> "Bachelor of Science and Arts"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#BachelorDegree> .

--- a/contracts/axone-dataverse/src/contract.rs
+++ b/contracts/axone-dataverse/src/contract.rs
@@ -89,6 +89,7 @@ pub mod execute {
     use crate::registrar::registry::ClaimRegistrar;
     use axone_rdf::dataset::Dataset;
     use axone_rdf::serde::NQuadsReader;
+    use cosmwasm_std::ensure;
     use std::io::BufReader;
 
     pub fn submit_claims(
@@ -108,8 +109,11 @@ pub mod execute {
         // signature serves as proof.
         if !vc.proof.is_empty() {
             vc.verify(&deps)?;
-        } else if !vc.is_issued_by(&info.sender) {
-            Err(VerificationError::NoSuitableProof)?;
+        } else {
+            ensure!(
+                vc.is_issued_by(&info.sender),
+                VerificationError::NoSuitableProof
+            );
         }
 
         let credential = DataverseCredential::try_from((env, info, &vc))?;

--- a/contracts/axone-dataverse/src/credential/rdf_marker.rs
+++ b/contracts/axone-dataverse/src/credential/rdf_marker.rs
@@ -10,6 +10,14 @@ pub const RDF_DATE_TYPE: NamedNode<'_> = NamedNode {
     iri: "http://www.w3.org/2001/XMLSchema#dateTime",
 };
 
+pub const RDF_UNSIGNED_INT: NamedNode<'_> = NamedNode {
+    iri: "http://www.w3.org/2001/XMLSchema#unsignedInt",
+};
+
+pub const RDF_UNSIGNED_LONG: NamedNode<'_> = NamedNode {
+    iri: "http://www.w3.org/2001/XMLSchema#unsignedLong",
+};
+
 pub const IRI_VC_TYPE: &str = "https://www.w3.org/2018/credentials#VerifiableCredential";
 pub const VC_RDF_TYPE: Term<'_> = Term::NamedNode(NamedNode { iri: IRI_VC_TYPE });
 pub const VC_RDF_ISSUER: NamedNode<'_> = NamedNode {

--- a/contracts/axone-dataverse/src/registrar/rdf.rs
+++ b/contracts/axone-dataverse/src/registrar/rdf.rs
@@ -1,4 +1,4 @@
-use crate::credential::rdf_marker::RDF_DATE_TYPE;
+use crate::credential::rdf_marker::{RDF_DATE_TYPE, RDF_UNSIGNED_INT, RDF_UNSIGNED_LONG};
 use crate::registrar::credential::DataverseCredential;
 use crate::ContractError;
 use axone_rdf::dataset::QuadIterator;
@@ -98,15 +98,17 @@ impl<'a> DataverseCredential<'a> {
             Triple {
                 subject: c_subject,
                 predicate: VC_HEADER_HEIGHT,
-                object: Term::Literal(Literal::Simple {
+                object: Term::Literal(Literal::Typed {
                     value: &self.height,
+                    datatype: RDF_UNSIGNED_LONG,
                 }),
             },
             Triple {
                 subject: c_subject,
                 predicate: VC_HEADER_TIMESTAMP,
-                object: Term::Literal(Literal::Simple {
+                object: Term::Literal(Literal::Typed {
                     value: &self.timestamp,
+                    datatype: RDF_UNSIGNED_LONG,
                 }),
             },
             Triple {
@@ -145,7 +147,10 @@ impl<'a> DataverseCredential<'a> {
             triples.push(Triple {
                 subject: c_subject,
                 predicate: VC_HEADER_TX,
-                object: Term::Literal(Literal::Simple { value: tx_index }),
+                object: Term::Literal(Literal::Typed {
+                    value: tx_index,
+                    datatype: RDF_UNSIGNED_INT,
+                }),
             });
         }
 
@@ -288,14 +293,14 @@ mod test {
             DataverseCredential::try_from((mock_env_addr(), message_info(&addr(SENDER), &[]), &vc))
                 .unwrap();
 
-        let expected = r#"<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#height> "12345" .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#timestamp> "1571797419" .
+        let expected = r#"<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#height> "12345"^^<http://www.w3.org/2001/XMLSchema#unsignedLong> .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#timestamp> "1571797419"^^<http://www.w3.org/2001/XMLSchema#unsignedLong> .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#sender> "cosmwasm1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qlm3aqg" .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#type> <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#validFrom> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#subject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#tx_index> "3" .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#tx_index> "3"^^<http://www.w3.org/2001/XMLSchema#unsignedInt> .
 _:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/axone/ontology/vnext/thesaurus/digital-service-category/Storage> .
 _:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#claim> _:c0 .
@@ -320,14 +325,14 @@ _:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/de
             DataverseCredential::try_from((mock_env_addr(), message_info(&addr(SENDER), &[]), &vc))
                 .unwrap();
 
-        let expected = r#"<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#height> "12345" .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#timestamp> "1571797419" .
+        let expected = r#"<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#height> "12345"^^<http://www.w3.org/2001/XMLSchema#unsignedLong> .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#timestamp> "1571797419"^^<http://www.w3.org/2001/XMLSchema#unsignedLong> .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#sender> "cosmwasm1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qlm3aqg" .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#type> <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#validFrom> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:body#subject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
-<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#tx_index> "3" .
+<https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential:header#tx_index> "3"^^<http://www.w3.org/2001/XMLSchema#unsignedInt> .
 _:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/axone/ontology/vnext/thesaurus/digital-service-category/Storage> .
 _:c0 <https://w3id.org/axone/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
 _:c0 <test:claim#named-hierarchy> _:a0 .

--- a/contracts/axone-dataverse/src/registrar/registry.rs
+++ b/contracts/axone-dataverse/src/registrar/registry.rs
@@ -7,7 +7,7 @@ use axone_cognitarium::parser::{
     WhereClause, IRI,
 };
 use axone_cognitarium_client::CognitariumClient;
-use cosmwasm_std::{DepsMut, StdResult, Storage, WasmMsg};
+use cosmwasm_std::{ensure, DepsMut, StdResult, Storage, WasmMsg};
 
 /// ClaimRegistrar is the entity responsible to manage claims (i.e. submission and revocation) into
 /// the Dataverse, ensuring that any pre-condition criteria to an action is met, and any attached
@@ -20,10 +20,29 @@ impl ClaimRegistrar {
     const RDF_DATA_FORMAT: DataFormat = DataFormat::NTriples;
 
     pub fn try_new(storage: &dyn Storage) -> StdResult<Self> {
-        let dataverse = DATAVERSE.load(storage)?;
-        Ok(Self {
+        DATAVERSE.load(storage).map(|dataverse| Self {
             triplestore: CognitariumClient::new(dataverse.triplestore_address),
         })
+    }
+
+    /// Checks if a credential exists in the triplestore by ID.
+    /// Returns `true` if at least one triple is found, `false` otherwise.
+    pub fn exists(&self, deps: &DepsMut<'_>, credential_id: &str) -> Result<bool, ContractError> {
+        let query = SelectQuery {
+            prefixes: Vec::new(),
+            limit: Some(1),
+            select: vec![SelectItem::Variable("p".into())],
+            r#where: WhereClause::Bgp {
+                patterns: vec![TriplePattern {
+                    subject: VarOrNode::Node(Node::NamedNode(IRI::Full(credential_id.into()))),
+                    predicate: VarOrNamedNode::Variable("p".into()),
+                    object: VarOrNodeOrLiteral::Variable("o".into()),
+                }],
+            },
+        };
+
+        let response = self.triplestore.select(deps.querier, query)?;
+        Ok(!response.results.bindings.is_empty())
     }
 
     pub fn submit_claim(
@@ -31,29 +50,10 @@ impl ClaimRegistrar {
         deps: &DepsMut<'_>,
         credential: &DataverseCredential<'_>,
     ) -> Result<WasmMsg, ContractError> {
-        let resp = self.triplestore.select(
-            deps.querier,
-            SelectQuery {
-                prefixes: vec![],
-                limit: Some(1u32),
-                select: vec![SelectItem::Variable("p".to_string())],
-                r#where: WhereClause::Bgp {
-                    patterns: vec![TriplePattern {
-                        subject: VarOrNode::Node(Node::NamedNode(IRI::Full(
-                            credential.id.to_string(),
-                        ))),
-                        predicate: VarOrNamedNode::Variable("p".to_string()),
-                        object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                    }],
-                },
-            },
-        )?;
-
-        if !resp.results.bindings.is_empty() {
-            Err(ContractError::CredentialAlreadyExists(
-                credential.id.to_string(),
-            ))?;
-        }
+        ensure!(
+            !self.exists(deps, &credential.id)?,
+            ContractError::CredentialAlreadyExists(credential.id.to_string())
+        );
 
         self.triplestore
             .insert_data(

--- a/contracts/axone-dataverse/src/registrar/registry.rs
+++ b/contracts/axone-dataverse/src/registrar/registry.rs
@@ -51,7 +51,7 @@ impl ClaimRegistrar {
         credential: &DataverseCredential<'_>,
     ) -> Result<WasmMsg, ContractError> {
         ensure!(
-            !self.exists(deps, &credential.id)?,
+            !self.exists(deps, credential.id)?,
             ContractError::CredentialAlreadyExists(credential.id.to_string())
         );
 

--- a/packages/axone-logic-bindings/src/term_parser.rs
+++ b/packages/axone-logic-bindings/src/term_parser.rs
@@ -14,7 +14,7 @@ struct Parser<'a> {
 }
 
 impl<'a> Parser<'a> {
-    pub fn new(slice: &'a [u8]) -> Parser<'_> {
+    pub fn new(slice: &'a [u8]) -> Parser<'a> {
         Parser { slice, index: 0 }
     }
 

--- a/packages/axone-wasm/src/uri.rs
+++ b/packages/axone-wasm/src/uri.rs
@@ -54,9 +54,9 @@ impl CosmwasmUri {
     }
 
     fn encode_query(self) -> String {
-        return form_urlencoded::Serializer::new(String::new())
+        form_urlencoded::Serializer::new(String::new())
             .append_pair(COSMWASM_QUERY_PARAM, self.raw_query.as_str())
-            .finish();
+            .finish()
     }
 }
 


### PR DESCRIPTION
Specify [RDF datatypes](https://www.w3.org/TR/rdf12-concepts/) explicitly for integer values of Dataverse VCs.
- `height` and `timestamp` (u64 ⇌ [xsd:unsignedLong](https://www.w3.org/TR/xmlschema11-2/#unsignedLong))
- `tx_index` (u32 ⇌ [xsd:unsignedInt](https://www.w3.org/TR/xmlschema11-2/#unsignedInt))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced RDF output now presents numeric values with explicit data type annotations for clearer data representation.
	- Introduced additional validation checks during credential submission to reduce the risk of duplicate entries.

- **Refactor**
	- Streamlined processing logic to improve stability and reliability across data handling and query operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->