### PR TITLE
Build/derives sorted

### DIFF
--- a/.sort-derives.toml
+++ b/.sort-derives.toml
@@ -1,0 +1,2 @@
+exclude = []
+preserve = false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,8 +1,10 @@
 [tasks.format-rust]
-args = ["fmt"]
-command = "cargo"
-dependencies = ["install-rustfmt"]
+dependencies = ["install-rustfmt", "install-cargo-sort-derives"]
 description = "Format rust sources files."
+script = [
+    "cargo fmt",
+    "cargo sort-derives"
+]
 
 [tasks.lint-rust-format]
 args = ["fmt", "--all", "--", "--check"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,16 +1,12 @@
 [tasks.format-rust]
 dependencies = ["install-rustfmt", "install-cargo-sort-derives"]
 description = "Format rust sources files."
-script = [
-    "cargo fmt",
-    "cargo sort-derives"
-]
+script = ["cargo fmt", "cargo sort-derives"]
 
 [tasks.lint-rust-format]
-args = ["fmt", "--all", "--", "--check"]
-command = "cargo"
-dependencies = ["install-rustfmt"]
-description = "Check format of sources files."
+dependencies = ["install-rustfmt", "install-cargo-sort-derives"]
+description = "Check formatting and derives order of rust source files."
+script = ["cargo fmt --all -- --check", "cargo sort-derives --check"]
 
 [tasks.lint-rust]
 args = ["cranky"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -652,6 +652,9 @@ install_crate = { crate_name = "cargo-hack", min_version = "0.6.14" }
 [tasks.install-cargo-machete]
 install_crate = { crate_name = "cargo-machete", min_version = "0.7.0" }
 
+[tasks.install-cargo-sort-derives]
+install_crate = { crate_name = "cargo-sort-derives", min_version = "0.10.0" }
+
 [tasks.publish-crates]
 args = [
   "workspaces",

--- a/contracts/axone-cognitarium/src/error.rs
+++ b/contracts/axone-cognitarium/src/error.rs
@@ -4,7 +4,7 @@ use rio_turtle::TurtleError;
 use rio_xml::RdfXmlError;
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
@@ -37,7 +37,7 @@ impl From<TurtleError> for ContractError {
     }
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, Error, PartialEq)]
 pub enum StoreError {
     #[error("Maximum triples number exceeded: {0}")]
     TripleCount(Uint128),
@@ -55,7 +55,7 @@ pub enum StoreError {
     InsertDataTripleCount(Uint128),
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, Error, PartialEq)]
 pub enum RDFParseError {
     #[error("Error parsing XML RDF: {0}")]
     Xml(String),

--- a/contracts/axone-cognitarium/src/msg.rs
+++ b/contracts/axone-cognitarium/src/msg.rs
@@ -261,7 +261,7 @@ pub struct StoreResponse {
 /// # StoreLimits
 /// Contains limitations regarding store usages.
 #[cw_serde]
-#[derive(Default, Builder)]
+#[derive(Builder, Default)]
 #[builder(default, setter(into, strip_option))]
 pub struct StoreLimits {
     /// The maximum number of triples the store can contain.

--- a/contracts/axone-cognitarium/src/querier/expression.rs
+++ b/contracts/axone-cognitarium/src/querier/expression.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{StdError, StdResult};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Expression {
     Constant(Term),
     Variable(usize),
@@ -97,7 +97,7 @@ impl HasBoundVariables for Expression {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Term {
     String(String),
     Boolean(bool),

--- a/contracts/axone-cognitarium/src/querier/plan.rs
+++ b/contracts/axone-cognitarium/src/querier/plan.rs
@@ -3,7 +3,7 @@ use crate::querier::variable::HasBoundVariables;
 use crate::state::{Object, Predicate, Subject};
 
 /// Represents a querying plan.
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct QueryPlan {
     /// References the ending node of the plan, when evaluated others nodes will be invoked in
     /// cascade.
@@ -14,7 +14,7 @@ pub struct QueryPlan {
     pub variables: Vec<PlanVariable>,
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PlanVariable {
     Basic(String),
     BlankNode(String),
@@ -45,7 +45,7 @@ impl QueryPlan {
 
 /// Represents a single part of the query plan processing. Each node is intended to provide a
 /// specific behavior given an evaluation context.
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum QueryNode {
     /// Match the triple pattern against the state. The triple elements can be either a variable or
     /// a constant value, in the case of a variable it'll be either provided by the context of
@@ -123,7 +123,7 @@ impl HasBoundVariables for QueryNode {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PatternValue<V> {
     Constant(V),
     Variable(usize),

--- a/contracts/axone-cognitarium/src/querier/variable.rs
+++ b/contracts/axone-cognitarium/src/querier/variable.rs
@@ -5,7 +5,7 @@ use axone_rdf::normalize::IdentifierIssuer;
 use cosmwasm_std::StdResult;
 use std::collections::BTreeSet;
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ResolvedVariable {
     Subject(Subject),
     Predicate(Predicate),
@@ -124,7 +124,7 @@ impl ResolvedVariable {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResolvedVariables {
     variables: Vec<Option<ResolvedVariable>>,
 }

--- a/contracts/axone-cognitarium/src/rdf/atom.rs
+++ b/contracts/axone-cognitarium/src/rdf/atom.rs
@@ -1,7 +1,7 @@
 use rio_api::model::{Literal, NamedNode, Triple};
 use std::fmt;
 
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Subject {
     NamedNode(String),
     BlankNode(String),
@@ -15,7 +15,7 @@ impl fmt::Display for Subject {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Property(pub String);
 
 impl fmt::Display for Property {
@@ -24,7 +24,7 @@ impl fmt::Display for Property {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Value {
     NamedNode(String),
     BlankNode(String),
@@ -43,7 +43,7 @@ impl fmt::Display for Value {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Atom {
     pub subject: Subject,
     pub property: Property,

--- a/contracts/axone-cognitarium/src/state/namespaces.rs
+++ b/contracts/axone-cognitarium/src/state/namespaces.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 /// there is no need to implement a garbage collector mechanism in case some namespaces are removed.
 pub const NAMESPACE_KEY_INCREMENT: Item<u128> = Item::new("namespace_key");
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Namespace {
     /// The namespace value.
     pub value: String,

--- a/contracts/axone-cognitarium/src/state/store.rs
+++ b/contracts/axone-cognitarium/src/state/store.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 pub const STORE: Item<Store> = Item::new("store");
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Store {
     pub owner: Addr,
     pub limits: StoreLimits,
@@ -33,7 +33,7 @@ impl From<Store> for StoreResponse {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StoreLimits {
     pub max_triple_count: Uint128,
     pub max_byte_size: Uint128,
@@ -72,7 +72,7 @@ impl From<StoreLimits> for msg::StoreLimits {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StoreStat {
     pub triple_count: Uint128,
     pub namespace_count: Uint128,

--- a/contracts/axone-cognitarium/src/state/triples.rs
+++ b/contracts/axone-cognitarium/src/state/triples.rs
@@ -34,7 +34,7 @@ pub fn triples<'a>() -> IndexedMap<TriplePK<'a>, Triple, TripleIndexes<'a>> {
     )
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Triple {
     pub subject: Subject,
     pub predicate: Predicate,
@@ -60,7 +60,7 @@ impl Triple {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Subject {
     Named(Node),
     Blank(BlankNode),
@@ -91,7 +91,7 @@ impl Subject {
 
 pub type Predicate = Node;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Object {
     Named(Node),
     Blank(BlankNode),
@@ -135,7 +135,7 @@ impl Object {
 pub const BLANK_NODE_SIZE: usize = 16usize;
 pub type BlankNode = u128;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Node {
     pub namespace: u128,
     pub value: String,
@@ -156,7 +156,7 @@ impl Node {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Literal {
     Simple { value: String },
     I18NString { value: String, language: String },

--- a/contracts/axone-dataverse/src/credential/error.rs
+++ b/contracts/axone-dataverse/src/credential/error.rs
@@ -1,7 +1,7 @@
 use axone_rdf::normalize::NormalizationError;
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum InvalidCredentialError {
     #[error("Missing identifier")]
     MissingIdentifier,
@@ -19,7 +19,7 @@ pub enum InvalidCredentialError {
     Malformed(String),
 }
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum InvalidProofError {
     #[error("Missing proof type")]
     MissingProofType,
@@ -53,7 +53,7 @@ pub enum InvalidProofError {
     Unsupported,
 }
 
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub enum VerificationError {
     #[error("Couldn't canonicalize document: {0}")]
     RdfCanonError(#[from] NormalizationError),

--- a/contracts/axone-dataverse/src/credential/proof.rs
+++ b/contracts/axone-dataverse/src/credential/proof.rs
@@ -297,7 +297,7 @@ impl<'a> TryFrom<(&'a Dataset<'a>, GraphName<'a>)> for Proof<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ProofPurpose {
     AssertionMethod,
     Unused,
@@ -449,7 +449,7 @@ pub struct DataIntegrityProof<'a> {
     options: Dataset<'a>,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DataIntegrityCryptoSuite {
     EddsaRdfc2022,
 }

--- a/contracts/axone-dataverse/src/error.rs
+++ b/contracts/axone-dataverse/src/error.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{Instantiate2AddressError, StdError};
 use cw_utils::PaymentError;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),

--- a/contracts/axone-dataverse/src/state.rs
+++ b/contracts/axone-dataverse/src/state.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 pub const DATAVERSE: Item<Dataverse> = Item::new("dataverse");
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Dataverse {
     pub name: String,
     pub triplestore_address: Addr,

--- a/contracts/axone-law-stone/src/error.rs
+++ b/contracts/axone-law-stone/src/error.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::StdError;
 use cw_utils::{ParseReplyError, PaymentError};
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
@@ -28,7 +28,7 @@ pub enum ContractError {
     Payment(#[from] PaymentError),
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, Error, PartialEq)]
 pub enum LogicAskResponseError {
     #[error("Could not parse term: {0}")]
     Parse(TermParseError),

--- a/contracts/axone-law-stone/src/state.rs
+++ b/contracts/axone-law-stone/src/state.rs
@@ -4,7 +4,7 @@ use crate::msg::ProgramResponse;
 use axone_objectarium_client::ObjectRef;
 use cw_storage_plus::{Item, Map};
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct LawStone {
     pub broken: bool,
     pub law: ObjectRef,

--- a/contracts/axone-objectarium/src/compress.rs
+++ b/contracts/axone-objectarium/src/compress.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 /// CompressionAlgorithm is an enumeration that defines the different compression algorithms
 /// supported for compressing the content of objects.
-#[derive(Serialize, Copy, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Sequence)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, JsonSchema, PartialEq, Sequence, Serialize)]
 pub enum CompressionAlgorithm {
     /// Represents the "No compression" algorithm.
     Passthrough,
@@ -42,7 +42,7 @@ impl CompressionAlgorithm {
     }
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, Error, PartialEq)]
 pub enum CompressionError {
     #[error("{0}")]
     Error(String),

--- a/contracts/axone-objectarium/src/error.rs
+++ b/contracts/axone-objectarium/src/error.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{StdError, Uint128};
 use cw_utils::PaymentError;
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
@@ -22,7 +22,7 @@ pub enum ContractError {
     Payment(#[from] PaymentError),
 }
 
-#[derive(Error, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, Error, PartialEq)]
 pub enum BucketError {
     #[error("Name of bucket could not be empty")]
     EmptyName,

--- a/contracts/axone-objectarium/src/msg.rs
+++ b/contracts/axone-objectarium/src/msg.rs
@@ -305,7 +305,7 @@ impl CompressionAlgorithm {
 ///
 /// The limits are optional and if not set, there is no limit.
 #[cw_serde]
-#[derive(Default, Builder)]
+#[derive(Builder, Default)]
 #[builder(default, setter(into, strip_option))]
 pub struct BucketLimits {
     /// The maximum total size of the objects in the bucket.
@@ -361,7 +361,7 @@ impl Default for PaginationConfig {
 ///
 /// BucketStat is the type of the statistics of a bucket.
 #[cw_serde]
-#[derive(Default, Builder)]
+#[derive(Builder, Default)]
 pub struct BucketStat {
     /// The total size of the objects contained in the bucket.
     pub size: Uint128,

--- a/contracts/axone-objectarium/src/state.rs
+++ b/contracts/axone-objectarium/src/state.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 pub const DATA: Map<Hash, Vec<u8>> = Map::new("DATA");
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 pub struct Bucket {
     /// The owner of the bucket.
     pub owner: Addr,
@@ -27,7 +27,7 @@ pub struct Bucket {
     pub stat: BucketStat,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 pub struct BucketStat {
     /// The total size of the objects contained in the bucket.
     pub size: Uint128,
@@ -65,7 +65,7 @@ impl Bucket {
 
 /// HashAlgorithm is an enumeration that defines the different hash algorithms
 /// supported for hashing the content of objects.
-#[derive(Serialize, Copy, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 pub enum HashAlgorithm {
     /// Represents the MD5 algorithm.
     MD5,
@@ -127,7 +127,7 @@ impl From<CompressionAlgorithm> for msg::CompressionAlgorithm {
 /// BucketConfig is the type of the configuration of a bucket.
 ///
 /// The configuration is set at the instantiation of the bucket, and is immutable and cannot be changed.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 pub struct BucketConfig {
     /// The algorithm used to hash the content of the objects to generate the id of the objects.
     /// The algorithm is optional and if not set, the default algorithm is used.
@@ -188,7 +188,7 @@ impl From<BucketConfig> for msg::BucketConfig {
 /// BucketLimits is the type of the limits of a bucket.
 ///
 /// The limits are optional and if not set, there is no limit.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 pub struct BucketLimits {
     /// The maximum total size of the objects in the bucket.
     pub max_total_size: Option<Uint128>,
@@ -272,7 +272,7 @@ impl TryFrom<msg::BucketLimits> for BucketLimits {
     }
 }
 /// Pagination is the type carrying configuration for paginated queries.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 pub struct Pagination {
     /// The maximum elements a page can contain.
     pub max_page_size: u32,
@@ -324,7 +324,7 @@ impl TryFrom<PaginationConfig> for Pagination {
 
 pub const BUCKET: Item<Bucket> = Item::new("bucket");
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 pub struct Object {
     /// The id of the object.
     pub id: Hash,
@@ -373,7 +373,7 @@ pub fn objects<'a>() -> IndexedMap<Hash, Object, ObjectIndexes<'a>> {
     )
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Pin {
     /// The id of the object.
     pub id: Hash,

--- a/packages/axone-logic-bindings/src/error.rs
+++ b/packages/axone-logic-bindings/src/error.rs
@@ -1,7 +1,7 @@
 use std::string::FromUtf8Error;
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, Error, PartialEq)]
 pub enum TermParseError {
     #[error("Value is not UTF-8 encoded: {0}")]
     NotUtf8Value(FromUtf8Error),

--- a/packages/axone-logic-bindings/src/query.rs
+++ b/packages/axone-logic-bindings/src/query.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::CustomQuery;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug)]
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LogicCustomQuery {
     Ask { program: String, query: String },
@@ -12,7 +12,7 @@ pub enum LogicCustomQuery {
 
 impl CustomQuery for LogicCustomQuery {}
 
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq, JsonSchema, Debug)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct AskResponse {
     pub height: u64,
@@ -21,7 +21,7 @@ pub struct AskResponse {
     pub user_output: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq, JsonSchema, Debug)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Answer {
     pub has_more: bool,
@@ -43,14 +43,14 @@ impl Answer {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq, JsonSchema, Debug)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Result {
     pub error: Option<String>,
     pub substitutions: Vec<Substitution>,
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq, JsonSchema, Debug)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Substitution {
     pub variable: String,

--- a/packages/axone-logic-bindings/src/term_parser.rs
+++ b/packages/axone-logic-bindings/src/term_parser.rs
@@ -1,7 +1,7 @@
 use crate::error::TermParseError;
 
 /// Represents a Prolog response term element which can be a tuple, an array or a string value.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TermValue {
     Tuple(Vec<TermValue>),
     Array(Vec<TermValue>),

--- a/packages/axone-objectarium-client/src/object.rs
+++ b/packages/axone-objectarium-client/src/object.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 const CONTRACT_NAME: &str = "axone-objectarium";
 
 /// Represents a reference to an Object stored in the `axone-objectarium` contract.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ObjectRef {
     /// The object id in the `axone-objectarium` contract.
     pub object_id: String,

--- a/packages/axone-rdf/src/dataset.rs
+++ b/packages/axone-rdf/src/dataset.rs
@@ -85,7 +85,7 @@ impl<'a> Dataset<'a> {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct QuadPattern<'a> {
     subject: Option<Subject<'a>>,
     predicate: Option<NamedNode<'a>>,

--- a/packages/axone-rdf/src/normalize.rs
+++ b/packages/axone-rdf/src/normalize.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, HashMap};
 use thiserror::Error;
 
 /// A RDF normalizer allowing to canonicalize RDF data, following the https://www.w3.org/TR/rdf-canon specification.
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Normalizer<'a> {
     blank_node_to_quads: HashMap<String, Vec<Quad<'a>>>,
     hash_to_blank_nodes: BTreeMap<String, Vec<String>>,
@@ -15,7 +15,7 @@ pub struct Normalizer<'a> {
     canonical_issuer: IdentifierIssuer,
 }
 
-#[derive(Error, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, Error, PartialEq)]
 pub enum NormalizationError {
     /// An unexpected error denotes an error that should never occur.  
     #[error("An unexpected error occurred: {0}")]
@@ -329,7 +329,7 @@ impl<'a> Default for Normalizer<'a> {
 }
 
 /// Canonical blank node identifier issuer, specified by: https://www.w3.org/TR/rdf-canon/#issue-identifier.
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IdentifierIssuer {
     prefix: String,
     pub counter: u128,

--- a/packages/axone-rdf/src/serde.rs
+++ b/packages/axone-rdf/src/serde.rs
@@ -18,7 +18,7 @@ pub struct NQuadsReader<R: BufRead> {
     parser: NQuadsParser<R>,
 }
 
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub enum NQuadsReadError {
     #[error("RDF Star notation not supported")]
     RDFStarUnsupported,

--- a/packages/axone-wasm/src/error.rs
+++ b/packages/axone-wasm/src/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 use url::ParseError;
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, Error, PartialEq)]
 pub enum CosmwasmUriError {
     #[error("{0}")]
     ParseURI(#[from] ParseError),

--- a/packages/axone-wasm/src/uri.rs
+++ b/packages/axone-wasm/src/uri.rs
@@ -20,7 +20,7 @@ const COSMWASM_QUERY_PARAM: &str = "query";
 /// - `{contract_name}`: Only informative, represents the corresponding smart contract name or type (e.g. `axone-objectarium`);
 /// - `{contract_address}`: The address of the smart contract to query;
 /// - `{contract_query}`: The JSON query to perform on the targeted smart contract, URL encoded;
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CosmwasmUri {
     pub contract_name: Option<String>,
     pub contract_address: String,
@@ -211,7 +211,7 @@ mod tests {
         }
     }
 
-    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
     struct TestQuery {
         pub content: String,
     }

--- a/templates/axone-smart-contract/{{ contract_name }}/src/error.rs
+++ b/templates/axone-smart-contract/{{ contract_name }}/src/error.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::StdError;
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),


### PR DESCRIPTION
Order must be preserved. The derives are now sorted.

- `format-rust` now runs [cargo fmt](https://github.com/rust-lang/rustfmt) + [cargo sort-derives](https://github.com/lusingander/cargo-sort-derives)
- `lint-rust-format` now checks both Rust formatting and derive ordering
- reformatted codebase accordingly
