### PR TITLE
Build/lock toolchain and lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+rustflags = ["-Dwarnings"]
+
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "link-arg=-s"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,11 +63,7 @@ jobs:
 
       - name: Setup rust
         if: steps.changed-rust-cargo.outputs.any_changed == 'true'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         if: steps.changed-rust-cargo.outputs.any_changed == 'true'
@@ -134,11 +130,7 @@ jobs:
 
       - name: Setup rust
         if: steps.changed-rust-files.outputs.any_changed == 'true'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         if: steps.changed-rust-files.outputs.any_changed == 'true'
@@ -156,11 +148,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1
@@ -187,11 +175,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1
@@ -227,11 +211,7 @@ jobs:
 
       - name: Setup rust
         if: steps.changed-toml-files.outputs.any_changed == 'true'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         if: steps.changed-toml-files.outputs.any_changed == 'true'
@@ -266,11 +246,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1
@@ -302,11 +278,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1
@@ -343,11 +315,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,11 +27,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,7 @@ jobs:
           force: true
 
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Setup rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81
-          default: true
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,18 +1,18 @@
 [tasks.format-rust]
-dependencies = ["install-rustfmt", "install-cargo-sort-derives"]
-description = "Format rust sources files."
+dependencies = ["install-cargo-sort-derives"]
+description = "Format rust sources files. (rustfmt provided by rust-toolchain.toml)"
 script = ["cargo fmt", "cargo sort-derives"]
 
 [tasks.lint-rust-format]
-dependencies = ["install-rustfmt", "install-cargo-sort-derives"]
-description = "Check formatting and derives order of rust source files."
+dependencies = ["install-cargo-sort-derives"]
+description = "Check formatting and derives order (rustfmt via rust-toolchain.toml)."
 script = ["cargo fmt --all -- --check", "cargo sort-derives --check"]
 
 [tasks.lint-rust]
 args = ["cranky"]
 command = "cargo"
-dependencies = ["install-clippy"]
-description = "Check lint of all sources files."
+dependencies = ["install-cranky"]
+description = "Check lint of all sources files (clippy via rust-toolchain.toml)."
 
 [tasks.lint-toml]
 args = ["lint"]
@@ -65,12 +65,8 @@ env = { RUSTFLAGS = "-D warnings" }
 [tasks.test-coverage]
 args = ["llvm-cov", "--workspace", "--lcov", "--output-path", "lcov.info"]
 command = "cargo"
-dependencies = ["install-llvm-tools-preview", "install-llvm-cov"]
+dependencies = ["install-llvm-cov"]
 
-[tasks.install-wasm]
-script = '''
-rustup target add wasm32-unknown-unknown
-'''
 
 [tasks.wasm]
 args = [
@@ -83,7 +79,7 @@ args = [
   "--locked",
 ]
 command = "cargo"
-dependencies = ["install-wasm", "install-cargo-hack"]
+dependencies = ["install-cargo-hack"]
 env = { RUSTFLAGS = "-C link-arg=-s" }
 
 [tasks.schema]
@@ -604,18 +600,8 @@ docker run --rm \
           | jq -r '.'
 '''
 
-[tasks.install-llvm-tools-preview]
-install_crate = { rustup_component_name = "llvm-tools-preview" }
-
-[tasks.install-clippy]
-install_crate = { rustup_component_name = "clippy" }
-
-[tasks.intall-cranky]
-dependencies = ["install-clippy"]
+[tasks.install-cranky]
 install_crate = { crate_name = "cranky", min_version = "0.3.0" }
-
-[tasks.install-rustfmt]
-install_crate = { rustup_component_name = "rustfmt" }
 
 [tasks.install-taplo-cli]
 install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help", min_version = "0.9.0" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -60,13 +60,11 @@ command = "cargo"
 args = ["test", "--lib", "--tests", "--workspace", "--locked"]
 command = "cargo"
 description = "Run all unit tests."
-env = { RUSTFLAGS = "-D warnings" }
 
 [tasks.test-coverage]
 args = ["llvm-cov", "--workspace", "--lcov", "--output-path", "lcov.info"]
 command = "cargo"
 dependencies = ["install-llvm-cov"]
-
 
 [tasks.wasm]
 args = [
@@ -80,7 +78,6 @@ args = [
 ]
 command = "cargo"
 dependencies = ["install-cargo-hack"]
-env = { RUSTFLAGS = "-C link-arg=-s" }
 
 [tasks.schema]
 workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.81.0"
+components = ["clippy", "rustfmt", "rust-src", "llvm-tools-preview"]
+profile = "minimal"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Stabilize builds by locking Rust toolchain, Clippy, and lint tooling versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Pin Rust toolchain (1.81.0) with clippy, rustfmt, rust-src, llvm-tools, and wasm target.
  - Enforce stricter builds (warnings as errors) and slimmer WASM output.
  - Add TOML lint/format tasks and aggregate lint/format commands across Rust and TOML.
  - Replace clippy install path with cranky; simplify WASM and coverage tooling.

- Refactor
  - Streamline Makefile tasks, removing redundant per-tool installers and consolidating workflows.
  - Rename and normalize tasks (e.g., install-cranky) for clearer, unified lint/format pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->