### PR TITLE
Refactor/remove owner from object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,7 @@ version = "7.0.0"
 dependencies = [
  "base16ct",
  "base64",
+ "bin-it",
  "bs58",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -396,6 +397,12 @@ name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
+name = "bin-it"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdc68b7631892303d28c13375b6a8a12508f6bbb9c8743518dad7b840d5610c"
 
 [[package]]
 name = "bitflags"

--- a/contracts/axone-law-stone/src/contract.rs
+++ b/contracts/axone-law-stone/src/contract.rs
@@ -8,9 +8,7 @@ use cw2::set_contract_version;
 use cw_utils::nonpayable;
 
 use axone_logic_bindings::LogicCustomQuery;
-use axone_objectarium::msg::{
-    ExecuteMsg as StorageMsg, ObjectPinsResponse, QueryMsg as StorageQuery,
-};
+use axone_objectarium::msg::{ExecuteMsg as StorageMsg, QueryMsg as StorageQuery};
 use axone_objectarium_client::ObjectRef;
 
 use crate::error::ContractError;
@@ -63,9 +61,9 @@ pub fn execute(
 }
 
 pub mod execute {
-    use cosmwasm_std::{ensure_eq, Order};
-
     use crate::state::{DEPENDENCIES, PROGRAM};
+    use axone_objectarium::msg::PinsForObjectResponse;
+    use cosmwasm_std::{ensure_eq, Order};
 
     use super::*;
 
@@ -93,10 +91,10 @@ pub mod execute {
 
         let law_release_msg = match deps
             .querier
-            .query_wasm_smart::<ObjectPinsResponse>(
+            .query_wasm_smart::<PinsForObjectResponse>(
                 stone.law.storage_address.clone(),
-                &StorageQuery::ObjectPins {
-                    id: stone.law.object_id.clone(),
+                &StorageQuery::PinsForObject {
+                    object_id: stone.law.object_id.clone(),
                     first: Some(1u32),
                     after: None,
                 },
@@ -295,7 +293,7 @@ mod tests {
     use axone_logic_bindings::{
         Answer, AskResponse, LogicCustomQuery, Result as LogicResult, Substitution,
     };
-    use axone_objectarium::msg::PageInfo;
+    use axone_objectarium::msg::{PageInfo, PinsForObjectResponse};
     use axone_wasm::uri::CosmwasmUri;
     use testing::addr::{addr, CREATOR, SENDER};
 
@@ -948,12 +946,12 @@ mod tests {
                     if contract_addr == "axone-objectarium1" =>
                 {
                     match from_json(msg) {
-                        Ok(StorageQuery::ObjectPins {
-                            id,
+                        Ok(StorageQuery::PinsForObject {
+                            object_id: id,
                             first: Some(1u32),
                             after: None,
                         }) if id == "program-id" => SystemResult::Ok(ContractResult::Ok(
-                            to_json_binary(&ObjectPinsResponse {
+                            to_json_binary(&PinsForObjectResponse {
                                 data: vec!["creator".to_string()],
                                 page_info: PageInfo {
                                     has_next_page: case.0 > 1,
@@ -1073,7 +1071,7 @@ mod tests {
                     SystemResult::Ok(ContractResult::Ok(to_json_binary(&contract_info).unwrap()))
                 }
                 WasmQuery::Smart { .. } => SystemResult::Ok(ContractResult::Ok(
-                    to_json_binary(&ObjectPinsResponse {
+                    to_json_binary(&PinsForObjectResponse {
                         data: vec![case.1.to_string()],
                         page_info: PageInfo {
                             has_next_page: false,

--- a/contracts/axone-objectarium/Cargo.toml
+++ b/contracts/axone-objectarium/Cargo.toml
@@ -23,6 +23,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 base16ct = { version = "0.2.0", features = ["alloc"] }
+bin-it = "1.2.0"
 bs58 = "0.5.1"
 cosmwasm-schema.workspace = true
 cosmwasm-std.workspace = true

--- a/contracts/axone-objectarium/src/cursor.rs
+++ b/contracts/axone-objectarium/src/cursor.rs
@@ -1,19 +1,8 @@
 use crate::crypto::Hash;
 use crate::msg::Cursor;
-use crate::state::{Object, Pin};
+use crate::state::{Object, Pin, PinPK};
+use bin_it::{BinaryReader, BinaryWriter};
 use cosmwasm_std::{Addr, StdError, StdResult};
-
-pub fn encode<I: AsRef<[u8]>>(id: I) -> Cursor {
-    bs58::encode(id).into_string()
-}
-
-pub fn decode<I: AsRef<[u8]>>(cursor: I) -> StdResult<Cursor> {
-    let raw = bs58::decode(cursor)
-        .into_vec()
-        .map_err(|err| StdError::parse_err("Cursor", err))?;
-
-    String::from_utf8(raw).map_err(|err| StdError::parse_err("Cursor", err))
-}
 
 pub trait AsCursor<PK> {
     fn encode_cursor(&self) -> StdResult<Cursor>;
@@ -22,90 +11,51 @@ pub trait AsCursor<PK> {
 
 impl AsCursor<Hash> for Object {
     fn encode_cursor(&self) -> StdResult<Cursor> {
-        Ok(bs58::encode(&self.id).into_string())
+        let mut writer = BinaryWriter::new();
+        writer.write_vec_u8(self.id.as_ref());
+
+        Ok(bs58::encode(writer.get_data()).into_string())
     }
 
     fn decode_cursor(cursor: Cursor) -> StdResult<Hash> {
-        bs58::decode(cursor)
+        let decoded = bs58::decode(cursor)
             .into_vec()
-            .map(Into::into)
-            .map_err(|err| StdError::parse_err("Cursor", err))
+            .map_err(|err| StdError::parse_err("Cursor", err))?;
+
+        let mut reader = BinaryReader::new(&decoded);
+        let hash = reader
+            .read_vec_u8()
+            .map_err(|err| StdError::parse_err("Cursor", err))?;
+
+        Ok(hash.into())
     }
 }
 
-impl AsCursor<(Addr, Hash)> for Pin {
+impl AsCursor<PinPK> for Pin {
     fn encode_cursor(&self) -> StdResult<Cursor> {
-        let pair = (self.address.as_str(), &self.id);
-        let json =
-            serde_json::to_vec(&pair).map_err(|err| StdError::serialize_err("Cursor", err))?;
+        let mut writer = BinaryWriter::new();
+        writer.write_vec_u8(self.id.as_ref());
+        writer.write_string(self.address.as_str());
 
-        Ok(bs58::encode(json).into_string())
-    }
-
-    fn decode_cursor(cursor: Cursor) -> StdResult<(Addr, Hash)> {
-        let data = bs58::decode(&cursor)
-            .into_vec()
-            .map_err(|err| StdError::parse_err("Cursor", err.to_string()))?;
-
-        let (addr_str, hash_bytes): (String, Vec<u8>) = serde_json::from_slice(&data)
-            .map_err(|err| StdError::parse_err("Cursor", err.to_string()))?;
-
-        Ok((Addr::unchecked(addr_str), hash_bytes.into()))
-    }
-}
-
-impl AsCursor<(Hash, Addr)> for Pin {
-    fn encode_cursor(&self) -> StdResult<Cursor> {
-        let pair = (&self.id, self.address.as_str());
-        let json =
-            serde_json::to_vec(&pair).map_err(|err| StdError::serialize_err("Cursor", err))?;
-
-        Ok(bs58::encode(json).into_string())
+        Ok(bs58::encode(writer.get_data()).into_string())
     }
 
     fn decode_cursor(cursor: Cursor) -> StdResult<(Hash, Addr)> {
-        let data = bs58::decode(&cursor)
+        let decoded = bs58::decode(cursor)
             .into_vec()
-            .map_err(|err| StdError::parse_err("Cursor", err.to_string()))?;
+            .map_err(|err| StdError::parse_err("Cursor", err))?;
 
-        let (hash_bytes, addr_str): (Vec<u8>, String) = serde_json::from_slice(&data)
-            .map_err(|err| StdError::parse_err("Cursor", err.to_string()))?;
+        let mut reader = BinaryReader::new(&decoded);
+        let hash = reader
+            .read_vec_u8()
+            .map_err(|err| StdError::parse_err("Cursor", err))?;
+        let addr = reader
+            .read_string()
+            .map_err(|err| StdError::parse_err("Cursor", err))?;
 
-        Ok((hash_bytes.into(), Addr::unchecked(addr_str)))
+        Ok((hash.into(), Addr::unchecked(addr)))
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn proper_encode() {
-        assert_eq!(encode(""), "".to_string());
-        assert_eq!(encode("an_id"), "BzZCCcK".to_string());
-    }
-
-    #[test]
-    fn proper_decode() {
-        assert_eq!(decode(""), Ok("".to_string()));
-        assert_eq!(decode("BzZCCcK"), Ok("an_id".to_string()));
-    }
-
-    #[test]
-    fn invalid_decode() {
-        assert_eq!(
-            decode("?"),
-            Err(StdError::parse_err(
-                "Cursor",
-                "provided string contained invalid character '?' at byte 0"
-            ))
-        );
-        assert_eq!(
-            decode("VtB5VXc"),
-            Err(StdError::parse_err(
-                "Cursor",
-                "invalid utf-8 sequence of 1 bytes from index 0"
-            ))
-        );
-    }
-}
+mod tests {}

--- a/contracts/axone-objectarium/src/msg.rs
+++ b/contracts/axone-objectarium/src/msg.rs
@@ -35,7 +35,7 @@ pub struct InstantiateMsg {
 #[cw_serde]
 pub enum ExecuteMsg {
     /// # StoreObject
-    /// StoreObject store an object to the bucket and make the sender the owner of the object.
+    /// StoreObject store an object to the bucket.
     /// The object is referenced by the hash of its content and this value is returned.
     /// If the object is already stored, it is a no-op. It may be pinned though.
     ///
@@ -97,8 +97,6 @@ pub enum QueryMsg {
     /// Objects returns the list of objects in the bucket with support for pagination.
     #[returns(ObjectsResponse)]
     Objects {
-        /// The owner of the objects to get.
-        address: Option<String>,
         /// The number of objects to return.
         first: Option<u32>,
         /// The point in the sequence to start returning objects.
@@ -113,13 +111,13 @@ pub enum QueryMsg {
         id: ObjectId,
     },
 
-    /// # ObjectPins
-    /// ObjectPins returns the list of addresses that pinned the object with the given id with
+    /// # PinsForObject
+    /// PinsForObject returns the list of addresses that pinned the object with the given id with
     /// support for pagination.
-    #[returns(ObjectPinsResponse)]
-    ObjectPins {
-        /// The id of the object to get the pins for.
-        id: ObjectId,
+    #[returns(PinsForObjectResponse)]
+    PinsForObject {
+        /// The id of the object for which to list all pinning addresses.
+        object_id: ObjectId,
         /// The number of pins to return.
         first: Option<u32>,
         /// The point in the sequence to start returning pins.
@@ -348,8 +346,6 @@ pub struct BucketStat {
 pub struct ObjectResponse {
     /// The id of the object.
     pub id: ObjectId,
-    /// The owner of the object.
-    pub owner: String,
     /// Tells if the object is pinned by at least one address.
     pub is_pinned: bool,
     /// The size of the object.
@@ -369,10 +365,10 @@ pub struct ObjectsResponse {
     pub page_info: PageInfo,
 }
 
-/// # ObjectPinsResponse
-/// ObjectPinsResponse is the response of the GetObjectPins query.
+/// # PinsForObjectResponse
+/// PinsForObjectResponse is the response of the GetObjectPins query.
 #[cw_serde]
-pub struct ObjectPinsResponse {
+pub struct PinsForObjectResponse {
     /// The list of addresses that pinned the object.
     pub data: Vec<String>,
     /// The page information.

--- a/docs/axone-objectarium.md
+++ b/docs/axone-objectarium.md
@@ -165,7 +165,7 @@ Execute messages
 
 ### ExecuteMsg::StoreObject
 
-StoreObject store an object to the bucket and make the sender the owner of the object. The object is referenced by the hash of its content and this value is returned. If the object is already stored, it is a no-op. It may be pinned though.
+StoreObject store an object to the bucket. The object is referenced by the hash of its content and this value is returned. If the object is already stored, it is a no-op. It may be pinned though.
 
 The "pin" parameter specifies whether the object should be pinned for the sender. Pinning an object ensures it is protected from being removed from storage, making it persistent and guaranteeing its indefinite accessibility. It’s important to note that pinning is optional; objects can be stored without pinning. However, be aware that non-pinned objects can be removed from the storage by anyone at any time, making them no longer accessible.
 
@@ -237,12 +237,11 @@ Object returns the object information with the given id.
 
 Objects returns the list of objects in the bucket with support for pagination.
 
-| parameter         | description                                                             |
-| ----------------- | ----------------------------------------------------------------------- |
-| `objects`         | _(Required.) _ **object**.                                              |
-| `objects.address` | **string\|null**. The owner of the objects to get.                      |
-| `objects.after`   | **string\|null**. The point in the sequence to start returning objects. |
-| `objects.first`   | **integer\|null**. The number of objects to return.                     |
+| parameter       | description                                                             |
+| --------------- | ----------------------------------------------------------------------- |
+| `objects`       | _(Required.) _ **object**.                                              |
+| `objects.after` | **string\|null**. The point in the sequence to start returning objects. |
+| `objects.first` | **integer\|null**. The number of objects to return.                     |
 
 ### QueryMsg::ObjectData
 
@@ -253,16 +252,16 @@ ObjectData returns the content of the object with the given id.
 | `object_data`    | _(Required.) _ **object**.                              |
 | `object_data.id` | _(Required.) _ **string**. The id of the object to get. |
 
-### QueryMsg::ObjectPins
+### QueryMsg::PinsForObject
 
-ObjectPins returns the list of addresses that pinned the object with the given id with support for pagination.
+PinsForObject returns the list of addresses that pinned the object with the given id with support for pagination.
 
-| parameter           | description                                                          |
-| ------------------- | -------------------------------------------------------------------- |
-| `object_pins`       | _(Required.) _ **object**.                                           |
-| `object_pins.after` | **string\|null**. The point in the sequence to start returning pins. |
-| `object_pins.first` | **integer\|null**. The number of pins to return.                     |
-| `object_pins.id`    | _(Required.) _ **string**. The id of the object to get the pins for. |
+| parameter                   | description                                                                              |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| `pins_for_object`           | _(Required.) _ **object**.                                                               |
+| `pins_for_object.after`     | **string\|null**. The point in the sequence to start returning pins.                     |
+| `pins_for_object.first`     | **integer\|null**. The number of pins to return.                                         |
+| `pins_for_object.object_id` | _(Required.) _ **string**. The id of the object for which to list all pinning addresses. |
 
 ### QueryMsg::undefined
 
@@ -306,7 +305,6 @@ ObjectResponse is the response of the Object query.
 | `compressed_size` | _(Required.) _ **[Uint128](#uint128)**. The size of the object when compressed. If the object is not compressed, the value is the same as `size`. |
 | `id`              | _(Required.) _ **string**. The id of the object.                                                                                                  |
 | `is_pinned`       | _(Required.) _ **boolean**. Tells if the object is pinned by at least one address.                                                                |
-| `owner`           | _(Required.) _ **string**. The owner of the object.                                                                                               |
 | `size`            | _(Required.) _ **[Uint128](#uint128)**. The size of the object.                                                                                   |
 
 ### object_data
@@ -318,17 +316,6 @@ This is only needed as serde-json-\{core,wasm\} has a horrible encoding for Vec&
 | type        |
 | ----------- |
 | **string**. |
-
-### object_pins
-
-ObjectPinsResponse is the response of the GetObjectPins query.
-
-| property                  | description                                                                           |
-| ------------------------- | ------------------------------------------------------------------------------------- |
-| `data`                    | _(Required.) _ **Array&lt;string&gt;**. The list of addresses that pinned the object. |
-| `page_info`               | _(Required.) _ **[PageInfo](#pageinfo)**. The page information.                       |
-| `page_info.cursor`        | **string**. The cursor to the next page.                                              |
-| `page_info.has_next_page` | **boolean**. Tells if there is a next page.                                           |
 
 ### objects
 
@@ -350,6 +337,17 @@ The contract's ownership info
 | `owner`          | **string\|null**. The contract's current owner. `None` if the ownership has been renounced.                                                                                                                  |
 | `pending_expiry` | **[Expiration](#expiration)\|null**. The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline. |
 | `pending_owner`  | **string\|null**. The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.                                                                          |
+
+### pins_for_object
+
+PinsForObjectResponse is the response of the GetObjectPins query.
+
+| property                  | description                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| `data`                    | _(Required.) _ **Array&lt;string&gt;**. The list of addresses that pinned the object. |
+| `page_info`               | _(Required.) _ **[PageInfo](#pageinfo)**. The page information.                       |
+| `page_info.cursor`        | **string**. The cursor to the next page.                                              |
+| `page_info.has_next_page` | **boolean**. Tells if there is a next page.                                           |
 
 ## Definitions
 
@@ -470,7 +468,6 @@ ObjectResponse is the response of the Object query.
 | `compressed_size` | _(Required.) _ **[Uint128](#uint128)**. The size of the object when compressed. If the object is not compressed, the value is the same as `size`. |
 | `id`              | _(Required.) _ **string**. The id of the object.                                                                                                  |
 | `is_pinned`       | _(Required.) _ **boolean**. Tells if the object is pinned by at least one address.                                                                |
-| `owner`           | _(Required.) _ **string**. The owner of the object.                                                                                               |
 | `size`            | _(Required.) _ **[Uint128](#uint128)**. The size of the object.                                                                                   |
 
 ### PageInfo
@@ -613,5 +610,5 @@ Any existing pending ownership transfer is overwritten.
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-objectarium.json` (`882a9cdfaa1f0b39`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-objectarium.json` (`13697e857ca43568`)*
 ````


### PR DESCRIPTION
Removes the _owner_ field from the `Object` structure, along with all associated logic.

In the `Objectarium`, you do not own an object. You can either retain it (by pinning) or let it go (by unpinning). The contract acts as a shared bucket with collaborative persistence — not a private file system.

Since this field provided no functional value beyond indicating who originally submitted the data (an information already retrievable via transaction history), it has been removed.

**Objectarium API Changes:**
- Drop address filter on QueryMsg::Objects
  → Object listing now returns all objects. Filtering by pinned status will be handled in a separate query.
- Rename ObjectPins to PinsForObject
  → More consistent naming: what is returned (Pins) comes first, followed by the context (ForObject).
- Change in cursor serialization format
  → Cursors now use a compact binary format, base58-encoded.

⚠️ _Breaking change_
This update breaks backward compatibility. However, the impact is minimal at this stage, as we’re in a transitional period where all contracts are being reshaped in preparation for mainnet — our new and final reference point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced pagination: more reliable cursors for object and pin listings.
  - Object listings now include is_pinned and compressed_size metadata.

- Refactor
  - Pins query renamed to PinsForObject with object_id; responses returned under PinsForObjectResponse.
  - Objects query simplified: removed owner/address filter; ObjectResponse no longer includes owner.
  - Pin listings for an object return addresses as strings.

- Documentation
  - Updated query and response names/descriptions for consistency.

- Chores
  - Internal dependency update to improve binary cursor handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->