### PR TITLE
Feat/objects pinned by

### DIFF
--- a/contracts/axone-objectarium/src/contract.rs
+++ b/contracts/axone-objectarium/src/contract.rs
@@ -2289,7 +2289,7 @@ mod tests {
     }
 
     #[test]
-    fn fetch_objects() {
+    fn objects() {
         let mut deps = mock_dependencies();
         let creator1 = addr("creator1");
         let creator2 = addr("creator2");
@@ -2411,7 +2411,79 @@ mod tests {
     }
 
     #[test]
-    fn object_pins() {
+    fn query_objects_pinned_by() {
+        let mut deps = mock_dependencies();
+        let creator1 = addr("creator1");
+        let creator2 = addr("creator2");
+
+        let info1 = message_info(&creator1, &[]);
+        let info2 = message_info(&creator2, &[]);
+
+        instantiate(
+            deps.as_mut(),
+            mock_env(),
+            info1.clone(),
+            InstantiateMsg {
+                owner: None,
+                bucket: "test".to_string(),
+                config: Default::default(),
+                limits: Default::default(),
+                pagination: Default::default(),
+            },
+        )
+        .unwrap();
+
+        let objects = vec![
+            ("object1", &info1, false),
+            ("object2", &info1, true),
+            ("object3", &info2, true),
+            ("object4", &info2, true),
+            ("object5", &info1, true),
+        ];
+
+        for (data, info, pin) in objects {
+            execute(
+                deps.as_mut(),
+                mock_env(),
+                info.clone(),
+                ExecuteMsg::StoreObject {
+                    data: Binary::from_base64(general_purpose::STANDARD.encode(data).as_str())
+                        .unwrap(),
+                    pin,
+                },
+            )
+            .unwrap();
+        }
+
+        let cases = vec![
+            (creator1.clone(), None, None, 2),
+            (creator2.clone(), None, None, 2),
+            (creator1.clone(), Some(1), None, 1),
+            (creator1, None, Some("D4menWGWo3hzhXpexzE6TTu8w9qU2Mcundpv13CsWP1osLVet7mpmtizLDNQbEeqvJcFQ5Gtn1wixWVRQySUxsxW7mH6yt7MrsC4MX4yRykaqza53PxFY5fZkwVmTC8PkrEoPWDGTS1mboh81T".to_string()), 1),
+            (creator2, Some(1), None, 1),
+        ];
+
+        for (address, first, after, expected_count) in cases {
+            let result: ObjectsResponse = from_json(
+                &query(
+                    deps.as_ref(),
+                    mock_env(),
+                    QueryMsg::ObjectsPinnedBy {
+                        address: address.to_string(),
+                        first,
+                        after,
+                    },
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+            assert_eq!(result.data.len(), expected_count);
+        }
+    }
+
+    #[test]
+    fn pins_for_object() {
         let mut deps = mock_dependencies();
         let info1 = message_info(&addr("creator1"), &[]);
         let info2 = message_info(&addr("creator2"), &[]);

--- a/contracts/axone-objectarium/src/msg.rs
+++ b/contracts/axone-objectarium/src/msg.rs
@@ -97,10 +97,10 @@ pub enum QueryMsg {
     /// Objects returns the list of objects in the bucket with support for pagination.
     #[returns(ObjectsResponse)]
     Objects {
-        /// The number of objects to return.
-        first: Option<u32>,
         /// The point in the sequence to start returning objects.
         after: Option<Cursor>,
+        /// The number of objects to return.
+        first: Option<u32>,
     },
 
     /// # ObjectData
@@ -111,6 +111,18 @@ pub enum QueryMsg {
         id: ObjectId,
     },
 
+    /// # ObjectsPinnedBy
+    /// ObjectsPinnedBy returns the list of objects pinned by the given address with support for pagination.
+    #[returns(ObjectsResponse)]
+    ObjectsPinnedBy {
+        /// The address whose pinned objects should be listed.
+        address: String,
+        /// The point in the sequence to start returning pinned objects.
+        after: Option<Cursor>,
+        /// The number of objects to return.
+        first: Option<u32>,
+    },
+
     /// # PinsForObject
     /// PinsForObject returns the list of addresses that pinned the object with the given id with
     /// support for pagination.
@@ -118,10 +130,10 @@ pub enum QueryMsg {
     PinsForObject {
         /// The id of the object for which to list all pinning addresses.
         object_id: ObjectId,
-        /// The number of pins to return.
-        first: Option<u32>,
         /// The point in the sequence to start returning pins.
         after: Option<Cursor>,
+        /// The number of pins to return.
+        first: Option<u32>,
     },
 }
 

--- a/docs/axone-objectarium.md
+++ b/docs/axone-objectarium.md
@@ -252,6 +252,17 @@ ObjectData returns the content of the object with the given id.
 | `object_data`    | _(Required.) _ **object**.                              |
 | `object_data.id` | _(Required.) _ **string**. The id of the object to get. |
 
+### QueryMsg::ObjectsPinnedBy
+
+ObjectsPinnedBy returns the list of objects pinned by the given address with support for pagination.
+
+| parameter                   | description                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------ |
+| `objects_pinned_by`         | _(Required.) _ **object**.                                                     |
+| `objects_pinned_by.address` | _(Required.) _ **string**. The address whose pinned objects should be listed.  |
+| `objects_pinned_by.after`   | **string\|null**. The point in the sequence to start returning pinned objects. |
+| `objects_pinned_by.first`   | **integer\|null**. The number of objects to return.                            |
+
 ### QueryMsg::PinsForObject
 
 PinsForObject returns the list of addresses that pinned the object with the given id with support for pagination.
@@ -318,6 +329,17 @@ This is only needed as serde-json-\{core,wasm\} has a horrible encoding for Vec&
 | **string**. |
 
 ### objects
+
+ObjectsResponse is the response of the Objects query.
+
+| property                  | description                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `data`                    | _(Required.) _ **Array&lt;[ObjectResponse](#objectresponse)&gt;**. The list of objects in the bucket. |
+| `page_info`               | _(Required.) _ **[PageInfo](#pageinfo)**. The page information.                                       |
+| `page_info.cursor`        | **string**. The cursor to the next page.                                                              |
+| `page_info.has_next_page` | **boolean**. Tells if there is a next page.                                                           |
+
+### objects_pinned_by
 
 ObjectsResponse is the response of the Objects query.
 
@@ -610,5 +632,5 @@ Any existing pending ownership transfer is overwritten.
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-objectarium.json` (`13697e857ca43568`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-objectarium.json` (`adc112e13d1b0a4e`)*
 ````


### PR DESCRIPTION
Introduces a new query endpoint `ObjectsPinnedBy`, which returns the list of _objects_ pinned by a specific _address_, with support for pagination.

```rust
ObjectsPinnedBy {
    address: String,
    first: Option<u32>,
    after: Option<Cursor>,
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a query to list objects pinned by a specific address, with pagination support. Responses include object ID, pinned status, size, and compressed size.

- Refactor
  - Standardized pagination parameter order across queries (after, first) for consistency. Clients using Objects and PinsForObject queries may need updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->