### PR TITLE
Build/bump axoned v13.0.0

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -348,7 +348,7 @@ condition = { fail_message = "🚫 The chain is already running" }
 condition_script = ["! docker ps -a | grep ${CHAIN} > /dev/null"]
 description = "Run the full node axoned application using the chain's home directory under a Docker container."
 script = '''
-echo "🚀 Starting chain ${CHAIN} under ${CHAIN_HOME}"
+echo "🚀 Starting chain ${CHAIN} under ${CHAIN_HOME} (using ${DOCKER_IMAGE_AXONEPROTOCOL_AXONED})"
 
 if [ ! -f ${CHAIN_HOME}/config/genesis.json ]; then
   echo "❌ The chain seems to be uninitialised. Try: cargo make chain-initialize"
@@ -657,7 +657,7 @@ CHAIN_MONIKER = "local-node"
 DIR_DEPLOY = "${DIR_TARGET}/deploy"
 DIR_TARGET = "./target"
 DIR_WASM = "${DIR_TARGET}/wasm32-unknown-unknown/release"
-DOCKER_IMAGE_AXONEPROTOCOL_AXONED = "axoneprotocol/axoned:8.0.0"
+DOCKER_IMAGE_AXONEPROTOCOL_AXONED = "axoneprotocol/axoned:13.0.0"
 DOCKER_IMAGE_COSMWASM_OPTIMIZER = "cosmwasm/optimizer:0.17.0"
 KEYRING_BACKEND = "test"
 MNEMONIC_ALICE = "code ceiling reduce repeat unfold intact cloud marriage nut remove illegal eternal pool frame mask rate buzz vintage pulp suggest loan faint snake spoon"

--- a/README.md
+++ b/README.md
@@ -293,9 +293,20 @@ To start the chain, just run:
 cargo make chain-start
 ```
 
-This will start the chain's container and run the full node wasmd application.
+Note: the default Docker image used by the tasks points to the latest released `axoned` version configured in `Makefile.toml`.
 
-You can check the chain's logs with:
+To temporarily run a different `axoned` image (for example to test a newer release), set the variable when invoking `cargo make`:
+
+```sh
+# override just for this run
+cargo make --env DOCKER_IMAGE_AXONEPROTOCOL_AXONED=axoneprotocol/axoned:13.1.0 chain-start
+```
+
+This will start the chain's container and run the full node `axoned` binary inside that image.
+
+### 🔍 Viewing chain logs
+
+Run this to follow the chain container logs in real time:
 
 ```sh
 cargo make chain-logs


### PR DESCRIPTION
Self explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  - Updated default Docker image to version 13.0.0.
  - Chain start output now displays the Docker image in use.

* Documentation
  - Clarified that chain tasks default to the latest released image.
  - Added instructions to temporarily override the Docker image for a single run.
  - Introduced steps to view and follow chain logs in real time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->