### PR TITLE
feat(vc): emit structured events for credential issuance

### DIFF
--- a/contracts/axone-vc/src/handlers/execute.rs
+++ b/contracts/axone-vc/src/handlers/execute.rs
@@ -2,7 +2,8 @@ use crate::{
     contract::{AxoneVc, AxoneVcResult},
     msg::AxoneVcExecuteMsg,
     services::issue_credential,
-    RESPONSE_KEY_CREDENTIAL_ID,
+    RESPONSE_KEY_CREDENTIAL_ID, RESPONSE_KEY_IDENTIFIER, RESPONSE_KEY_ISSUED_AT,
+    RESPONSE_KEY_ISSUER, RESPONSE_KEY_SUBJECT, RESPONSE_KEY_TYPES,
 };
 
 use abstract_app::traits::AbstractResponse;
@@ -43,6 +44,19 @@ fn execute_issue_credential(
 
     Ok(module.custom_response(
         "issue_credential",
-        vec![(RESPONSE_KEY_CREDENTIAL_ID.to_string(), result.credential_id)],
+        vec![
+            (
+                RESPONSE_KEY_CREDENTIAL_ID.to_string(),
+                result.credential_id.clone(),
+            ),
+            (RESPONSE_KEY_IDENTIFIER.to_string(), result.credential_id),
+            (RESPONSE_KEY_ISSUER.to_string(), result.issuer),
+            (RESPONSE_KEY_SUBJECT.to_string(), result.subject),
+            (RESPONSE_KEY_TYPES.to_string(), result.types.join(",")),
+            (
+                RESPONSE_KEY_ISSUED_AT.to_string(),
+                result.issued_at.to_string(),
+            ),
+        ],
     ))
 }

--- a/contracts/axone-vc/src/lib.rs
+++ b/contracts/axone-vc/src/lib.rs
@@ -18,6 +18,11 @@ pub const AXONE_VC_NAME: &str = "axone-vc";
 pub const AXONE_VC_ID: &str = const_format::concatcp!(AXONE_NAMESPACE, ":", AXONE_VC_NAME);
 pub const RESPONSE_KEY_AUTHORITY: &str = "authority";
 pub const RESPONSE_KEY_CREDENTIAL_ID: &str = "credential_id";
+pub const RESPONSE_KEY_IDENTIFIER: &str = "identifier";
+pub const RESPONSE_KEY_ISSUER: &str = "issuer";
+pub const RESPONSE_KEY_SUBJECT: &str = "subject";
+pub const RESPONSE_KEY_TYPES: &str = "types";
+pub const RESPONSE_KEY_ISSUED_AT: &str = "issued_at";
 
 // oxrdf pulls rand/getrandom transitively, but CosmWasm contracts must not depend
 // on host randomness. This custom backend keeps wasm32-unknown-unknown builds

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -7,12 +7,16 @@ use crate::{
     translation::{decode_nquads_credential, CredentialDecodingError},
 };
 
-use cosmwasm_std::Storage;
+use cosmwasm_std::{Storage, Timestamp};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq)]
 pub struct IssueCredentialResult {
     pub credential_id: String,
+    pub issuer: String,
+    pub subject: String,
+    pub types: Vec<String>,
+    pub issued_at: Timestamp,
 }
 
 #[derive(Debug, Error, PartialEq)]
@@ -33,12 +37,17 @@ pub fn issue_credential(
     format: CredentialInputFormat,
 ) -> AxoneVcResult<IssueCredentialResult> {
     let authority = authority(storage)?;
-    let (credential_id, record) =
-        issue_credential_with_authority(storage, authority, input, format)?;
+    let (credential, record) = issue_credential_with_authority(storage, authority, input, format)?;
 
-    record_credential(storage, credential_id.as_str(), &record)?;
+    record_credential(storage, credential.id(), &record)?;
 
-    Ok(IssueCredentialResult { credential_id })
+    Ok(IssueCredentialResult {
+        credential_id: credential.id().clone(),
+        issuer: credential.issuer().clone(),
+        subject: credential.subject_id().clone(),
+        types: credential.types().clone(),
+        issued_at: credential.issuance_date(),
+    })
 }
 
 fn issue_credential_with_authority(
@@ -46,7 +55,7 @@ fn issue_credential_with_authority(
     authority: crate::domain::Authority,
     input: &[u8],
     format: CredentialInputFormat,
-) -> Result<(String, CredentialRecord), IssueCredentialError> {
+) -> Result<(Credential, CredentialRecord), IssueCredentialError> {
     let decoded = match format {
         CredentialInputFormat::NQuads => decode_nquads_credential(input)?,
     };
@@ -57,10 +66,7 @@ fn issue_credential_with_authority(
         return Err(IssueCredentialError::CredentialAlreadyExists);
     }
 
-    Ok((
-        credential.id().clone(),
-        CredentialRecord::new(canonical_nquads),
-    ))
+    Ok((credential, CredentialRecord::new(canonical_nquads)))
 }
 
 #[cfg(test)]
@@ -127,6 +133,16 @@ mod tests {
         .expect("submit should succeed");
 
         assert_eq!(result.credential_id, credential_id);
+        assert_eq!(result.issuer, authority.did());
+        assert_eq!(result.subject, "did:example:subject");
+        assert_eq!(
+            result.types,
+            vec!["https://www.w3.org/2018/credentials#VerifiableCredential"]
+        );
+        assert_eq!(
+            result.issued_at,
+            cosmwasm_std::Timestamp::from_seconds(1_735_689_600)
+        );
 
         let record = load_credential(deps.as_ref().storage, credential_id)
             .expect("credential should be persisted");

--- a/contracts/axone-vc/tests/integration.rs
+++ b/contracts/axone-vc/tests/integration.rs
@@ -14,6 +14,7 @@ const RESOURCE_LICENSE_ASSERTION: &str = include_str!("fixtures/resource-license
 const VC_ISSUER_PREDICATE: &str = "<https://www.w3.org/2018/credentials#issuer>";
 const SOURCE_ISSUER_DID: &str =
     "<did:pkh:cosmos:axone-1:cosmos1s7auhjsmvjpiubqwco6bxxehsqwnvepvabhbrv>";
+const ABSTRACT_EVENT_TYPE: &str = "wasm-abstract";
 
 struct TestEnv<Env: CwEnv> {
     app: Application<Env, AxoneVcInterface<Env>>,
@@ -68,6 +69,57 @@ fn issue_credential_accepts_resource_license_assertion_example() -> anyhow::Resu
     let credential = resource_license_assertion_payload(&authority.did);
 
     env.app.issue_credential(Binary::from(credential), None)?;
+
+    Ok(())
+}
+
+#[test]
+fn issue_credential_emits_event() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    let credential = resource_license_assertion_payload(&authority.did);
+
+    let response = env.app.issue_credential(
+        Binary::from(credential),
+        Some(CredentialInputFormat::NQuads),
+    )?;
+
+    assert_eq!(
+        response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "action")
+            .expect("Missing action attribute"),
+        "issue_credential"
+    );
+    assert_eq!(
+        response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "identifier")
+            .expect("Missing identifier attribute"),
+        "https://credentials.axone.xyz/assertion/resource-license"
+    );
+    assert_eq!(
+        response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "issuer")
+            .expect("Missing issuer attribute"),
+        authority.did
+    );
+    assert_eq!(
+        response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "subject")
+            .expect("Missing subject attribute"),
+        "urn:uuid:5d29ea71-003f-46e7-a74d-d8d598629ed8"
+    );
+    assert_eq!(
+        response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "types")
+            .expect("Missing types attribute"),
+        "https://w3id.org/axone/ontology/v4/schema/core/assertion/AssertionCredential,https://www.w3.org/2018/credentials#VerifiableCredential"
+    );
+    assert_eq!(
+        response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "issued_at")
+            .expect("Missing issued_at attribute"),
+        "1781128800.000000000"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
When `IssueCredential` succeeds, emit an event containing:

```rust
action = "issue_credential"
identifier
issuer
subject
types
issued_at
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credential issuance responses now include enriched metadata: issuer, subject, credential types, and issued timestamp, alongside credential ID.

* **Tests**
  * Added integration test validating credential issuance event responses include all expected metadata attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->