### PR TITLE
ci(workflow): add stimulate-testnet workflow

### DIFF
--- a/.github/workflows/stimulate-testnet.yml
+++ b/.github/workflows/stimulate-testnet.yml
@@ -1,0 +1,72 @@
+name: Stimulate / Testnet
+
+"on":
+  schedule:
+    - cron: "0 * * * *"
+
+  workflow_dispatch:
+    inputs:
+      count:
+        description: Number of Abstract Accounts to create
+        required: false
+        default: "5"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stimulate-testnet
+  cancel-in-progress: false
+
+jobs:
+  create-abstract-accounts:
+    if: github.repository == 'axone-protocol/contracts'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Cache cargo registry
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Setup rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1
+
+      - name: Install cargo make
+        uses: davidB/rust-cargo-make@184c522bf8152f601a20749ca36c742b57ba568b  # v1
+
+      - name: Validate count
+        shell: bash
+        env:
+          ACCOUNT_COUNT: ${{ github.event.inputs.count || '5' }}
+        run: |
+          set -euo pipefail
+
+          count="${ACCOUNT_COUNT}"
+          if ! [[ "${count}" =~ ^[0-9]+$ ]]; then
+            echo "count must be an integer" >&2
+            exit 1
+          fi
+          if (( count < 1 || count > 50 )); then
+            echo "count must be between 1 and 50" >&2
+            exit 1
+          fi
+
+      - name: Create Abstract Accounts on Axone testnet
+        env:
+          ACCOUNT_COUNT: ${{ github.event.inputs.count || '5' }}
+          RUST_LOG: info
+          TEST_MNEMONIC: ${{ secrets.AXONE_GITHUB_TESTNET_WALLET }}
+        run: cargo make create-abstract-accounts testnet -- --count "${ACCOUNT_COUNT}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
 name = "axone-scripts"
 version = "0.1.0"
 dependencies = [
+ "abstract-client",
  "abstract-interface",
  "abstract-std",
  "anyhow",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -121,7 +121,15 @@ command = "cargo"
 description = "Run all unit tests."
 
 [tasks.test-coverage]
-args = ["llvm-cov", "--workspace", "--lcov", "--output-path", "lcov.info"]
+args = [
+  "llvm-cov",
+  "--workspace",
+  "--lcov",
+  "--output-path",
+  "lcov.info",
+  "--ignore-filename-regex",
+  "scripts/src/bin/.*",
+]
 category = "Testing"
 command = "cargo"
 dependencies = ["install-llvm-cov"]
@@ -524,6 +532,31 @@ done
 
 echo "🔎 Listing Abstract deployment info for networks: ${networks}"
 cargo run --bin deploy_abstract_info --package axone-scripts -- --network-ids ${networks}
+'''
+
+[tasks.create-abstract-accounts]
+category = "Deployment"
+description = "Create synthetic Abstract Accounts on a network. Usage: cargo make create-abstract-accounts [network-id] [-- --count 5]"
+script = '''
+network="${1:-testnet}"
+if [ "$#" -gt 0 ]
+then
+  shift
+fi
+
+if [ "${1:-}" = "--" ]
+then
+  shift
+fi
+
+case "$network" in
+  local|axone-localnet)
+    cargo make chain-start
+    ;;
+esac
+
+echo "🧬 Creating Abstract Accounts on ${network} with args: $*"
+cargo run --bin create_abstract_accounts --package axone-scripts -- --network-id "${network}" "$@"
 '''
 
 [tasks.deploy-install]

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ contract-query - Query a specific contract. The contract must be already deploye
 
 Deployment
 ----------
+create-abstract-accounts - Create synthetic Abstract Accounts on a network. Usage: cargo make create-abstract-accounts [network-id] [-- --count 5]
 deploy-abstract - Deploy Abstract infrastructure to specified networks. Usage: cargo make deploy-abstract <network-ids...>
 deploy-abstract-info - List Abstract deployment info for specified networks. Usage: cargo make deploy-abstract-info <network-ids...>
 deploy-contract - Publish a contract to Abstract on specified networks. Usage: cargo make deploy-contract <contract-name> <network-ids...>

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -12,7 +12,12 @@ path = "src/bin/deploy_abstract.rs"
 name = "deploy_abstract_info"
 path = "src/bin/deploy_abstract_info.rs"
 
+[[bin]]
+name = "create_abstract_accounts"
+path = "src/bin/create_abstract_accounts.rs"
+
 [dependencies]
+abstract-client.workspace = true
 abstract-interface.workspace = true
 abstract-std.workspace = true
 anyhow = { workspace = true }

--- a/scripts/src/bin/create_abstract_accounts.rs
+++ b/scripts/src/bin/create_abstract_accounts.rs
@@ -1,0 +1,178 @@
+//! Create synthetic Abstract Accounts on a target network.
+
+use abstract_client::AbstractClient;
+use axone_networks::parse_network as parse_axone_network;
+use clap::Parser;
+use cw_orch::{anyhow, daemon::networks::ChainInfo, prelude::*, tokio::runtime::Runtime};
+use log::info;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const DEFAULT_COUNT: u8 = 5;
+const MAX_COUNT: u8 = 50;
+const DEFAULT_NAME_PREFIX: &str = "axone-testnet-identity";
+const DEFAULT_DESCRIPTION: &str =
+    "Synthetic AXONE testnet identity generated for traffic stimulation.";
+const DEFAULT_LINK: &str = "https://axone.xyz/testnet";
+const MAX_ABSTRACT_NAME_LENGTH: usize = 64;
+
+fn create_abstract_accounts(network: ChainInfo, args: &Arguments) -> anyhow::Result<()> {
+    info!(
+        "Creating {} Abstract Account(s) on {}...",
+        args.count, network.chain_id
+    );
+
+    let rt = Runtime::new()?;
+    let chain = DaemonBuilder::new(network.clone())
+        .handle(rt.handle())
+        .build()?;
+
+    info!("Connected to: {}", network.chain_id);
+    info!("Sender: {}", chain.sender_addr());
+
+    let abstract_client = AbstractClient::new(chain)?;
+    let run_marker = run_marker();
+
+    for index in 1..=args.count {
+        let name = account_name(&args.name_prefix, &run_marker, index);
+        let account = abstract_client
+            .account_builder()
+            .name(name.clone())
+            .description(args.description.clone())
+            .link(args.link.clone())
+            .build()?;
+
+        info!(
+            "Created Abstract Account {}/{}: id={}, address={}",
+            index,
+            args.count,
+            account.id()?,
+            account.address()?
+        );
+    }
+
+    Ok(())
+}
+
+fn parse_count(input: &str) -> Result<u8, String> {
+    let count = input
+        .parse::<u8>()
+        .map_err(|_| format!("count must be an integer between 1 and {MAX_COUNT}"))?;
+
+    if !(1..=MAX_COUNT).contains(&count) {
+        return Err(format!("count must be between 1 and {MAX_COUNT}"));
+    }
+
+    Ok(count)
+}
+
+fn account_name(prefix: &str, run_marker: &str, index: u8) -> String {
+    let suffix = format!("-{run_marker}-{index}");
+    let max_prefix_len = MAX_ABSTRACT_NAME_LENGTH.saturating_sub(suffix.len());
+    let prefix = truncate_ascii(prefix, max_prefix_len);
+
+    format!("{prefix}{suffix}")
+}
+
+fn truncate_ascii(value: &str, max_len: usize) -> String {
+    let mut result = String::with_capacity(max_len);
+    for ch in value.chars() {
+        if result.len() + ch.len_utf8() > max_len {
+            break;
+        }
+        result.push(ch);
+    }
+    result
+}
+
+fn run_marker() -> String {
+    if let Ok(run_id) = std::env::var("GITHUB_RUN_ID") {
+        let attempt = std::env::var("GITHUB_RUN_ATTEMPT").unwrap_or_else(|_| "1".to_string());
+        return format!("gh{run_id}a{attempt}");
+    }
+
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    format!("local{seconds}")
+}
+
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+struct Arguments {
+    /// Network ID to create accounts on (e.g., testnet, axone-dendrite-2)
+    #[arg(short, long, default_value = "testnet")]
+    network_id: String,
+    /// Number of Abstract Accounts to create.
+    #[arg(short, long, default_value_t = DEFAULT_COUNT, value_parser = parse_count)]
+    count: u8,
+    /// Prefix used for generated Abstract Account names.
+    #[arg(long, default_value = DEFAULT_NAME_PREFIX)]
+    name_prefix: String,
+    /// Description stored in each Abstract Account.
+    #[arg(long, default_value = DEFAULT_DESCRIPTION)]
+    description: String,
+    /// Link stored in each Abstract Account.
+    #[arg(long, default_value = DEFAULT_LINK)]
+    link: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    dotenv::dotenv().ok();
+    env_logger::init();
+
+    let args = Arguments::parse();
+    let network = parse_axone_network(&args.network_id)
+        .or_else(|_| networks::parse_network(&args.network_id))
+        .map_err(anyhow::Error::msg)?;
+
+    create_abstract_accounts(network, &args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_count_accepts_valid_values() {
+        assert_eq!(parse_count("1"), Ok(1));
+        assert_eq!(parse_count("5"), Ok(5));
+        assert_eq!(parse_count("50"), Ok(50));
+    }
+
+    #[test]
+    fn parse_count_rejects_invalid_values() {
+        assert!(parse_count("0").is_err());
+        assert!(parse_count("51").is_err());
+        assert!(parse_count("abc").is_err());
+    }
+
+    #[test]
+    fn account_name_includes_run_marker_and_index() {
+        assert_eq!(
+            account_name("axone-testnet-identity", "gh123a1", 5),
+            "axone-testnet-identity-gh123a1-5"
+        );
+    }
+
+    #[test]
+    fn account_name_is_capped_to_abstract_limit() {
+        let name = account_name(
+            "a-very-long-prefix-that-would-exceed-the-abstract-account-name-limit",
+            "gh123456789a1",
+            50,
+        );
+
+        assert!(name.len() <= MAX_ABSTRACT_NAME_LENGTH);
+        assert!(name.ends_with("-gh123456789a1-50"));
+    }
+
+    #[test]
+    fn account_name_is_capped_to_abstract_limit_with_multibyte_prefix() {
+        let name = account_name("identity-🧪🧪🧪🧪🧪🧪🧪🧪🧪🧪", "gh123456789a1", 50);
+
+        assert!(name.len() <= MAX_ABSTRACT_NAME_LENGTH);
+        assert!(name.ends_with("-gh123456789a1-50"));
+        assert!(name.is_char_boundary(name.len()));
+    }
+}


### PR DESCRIPTION
This one gives [dendrite-2](https://github.com/axone-protocol/networks/blob/main/chains/dendrite-2/README.md) a small heartbeat.

Creates 5 minimal [Abstract Accounts](https://docs.abstract.money/) every hour on [Axone](https://axone.xyz) testnet to generate regular on-chain activity for indexers/UIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new workflow to create Abstract Accounts on the testnet, with both scheduled and manual runs.
  * Introduced a new task to generate multiple accounts from the command line, including support for choosing a network and passing a count.
  * Updated the README with usage for the new account-creation task.

* **Tests**
  * Added validation coverage for account count limits and account name formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->