### PR TITLE
✨ Feat/revoke verifiable credential

### DIFF
--- a/contracts/axone-vc/src/error.rs
+++ b/contracts/axone-vc/src/error.rs
@@ -1,4 +1,4 @@
-use crate::services::IssueCredentialError;
+use crate::services::{IssueCredentialError, RevokeCredentialError};
 use abstract_app::sdk::AbstractSdkError;
 use abstract_app::std::AbstractError;
 use abstract_app::AppError;
@@ -25,4 +25,7 @@ pub enum AxoneVcError {
 
     #[error(transparent)]
     IssueCredential(#[from] IssueCredentialError),
+
+    #[error(transparent)]
+    RevokeCredential(#[from] RevokeCredentialError),
 }

--- a/contracts/axone-vc/src/handlers/execute.rs
+++ b/contracts/axone-vc/src/handlers/execute.rs
@@ -3,10 +3,10 @@ use crate::{
     msg::AxoneVcExecuteMsg,
     services::issue_credential,
     RESPONSE_KEY_CREDENTIAL_ID, RESPONSE_KEY_IDENTIFIER, RESPONSE_KEY_ISSUED_AT,
-    RESPONSE_KEY_ISSUER, RESPONSE_KEY_SUBJECT, RESPONSE_KEY_TYPES,
+    RESPONSE_KEY_ISSUER, RESPONSE_KEY_REVOKED_AT, RESPONSE_KEY_SUBJECT, RESPONSE_KEY_TYPES,
 };
 
-use crate::domain::Uri;
+use crate::services::revoke_credential;
 use abstract_app::traits::AbstractResponse;
 use cosmwasm_std::{DepsMut, Env, MessageInfo};
 
@@ -66,11 +66,27 @@ fn execute_issue_credential(
 }
 
 fn execute_revoke_credential(
-    _deps: DepsMut<'_>,
-    _env: Env,
-    _info: MessageInfo,
+    deps: DepsMut<'_>,
+    env: Env,
+    info: MessageInfo,
     module: AxoneVc,
-    _identifier: Uri,
+    identifier: String,
 ) -> AxoneVcResult {
-    Ok(module.response("todo"))
+    module
+        .admin
+        .assert_admin(deps.as_ref(), &env, &info.sender)?;
+
+    let result = revoke_credential(deps.storage, &identifier, env.block.time)?;
+
+    Ok(module.custom_response(
+        "revoke_credential",
+        vec![
+            (RESPONSE_KEY_IDENTIFIER.to_string(), result.identifier),
+            (RESPONSE_KEY_ISSUER.to_string(), result.issuer),
+            (
+                RESPONSE_KEY_REVOKED_AT.to_string(),
+                result.revoked_at.to_string(),
+            ),
+        ],
+    ))
 }

--- a/contracts/axone-vc/src/handlers/execute.rs
+++ b/contracts/axone-vc/src/handlers/execute.rs
@@ -6,6 +6,7 @@ use crate::{
     RESPONSE_KEY_ISSUER, RESPONSE_KEY_SUBJECT, RESPONSE_KEY_TYPES,
 };
 
+use crate::domain::Uri;
 use abstract_app::traits::AbstractResponse;
 use cosmwasm_std::{DepsMut, Env, MessageInfo};
 
@@ -25,6 +26,9 @@ pub fn execute_handler(
             credential.as_slice(),
             format.unwrap_or_default(),
         ),
+        AxoneVcExecuteMsg::RevokeCredential { identifier } => {
+            execute_revoke_credential(deps, env, info, module, identifier)
+        }
     }
 }
 
@@ -59,4 +63,14 @@ fn execute_issue_credential(
             ),
         ],
     ))
+}
+
+fn execute_revoke_credential(
+    _deps: DepsMut<'_>,
+    _env: Env,
+    _info: MessageInfo,
+    module: AxoneVc,
+    _identifier: Uri,
+) -> AxoneVcResult {
+    Ok(module.response("todo"))
 }

--- a/contracts/axone-vc/src/lib.rs
+++ b/contracts/axone-vc/src/lib.rs
@@ -23,6 +23,7 @@ pub const RESPONSE_KEY_ISSUER: &str = "issuer";
 pub const RESPONSE_KEY_SUBJECT: &str = "subject";
 pub const RESPONSE_KEY_TYPES: &str = "types";
 pub const RESPONSE_KEY_ISSUED_AT: &str = "issued_at";
+pub const RESPONSE_KEY_REVOKED_AT: &str = "revoked_at";
 
 // oxrdf pulls rand/getrandom transitively, but CosmWasm contracts must not depend
 // on host randomness. This custom backend keeps wasm32-unknown-unknown builds

--- a/contracts/axone-vc/src/msg.rs
+++ b/contracts/axone-vc/src/msg.rs
@@ -51,6 +51,18 @@ pub enum AxoneVcExecuteMsg {
         #[serde(default)]
         format: Option<CredentialInputFormat>,
     },
+
+    /// Revoke a verifiable credential from this authority.
+    ///
+    /// Only the app authority is allowed to call this message.
+    ///
+    /// The revocation is terminal, the same identifier cannot be issued again.
+    ///
+    /// Revocation fails if the identifier is unknown or already revoked.
+    RevokeCredential {
+        /// The credential identifier to revoke.
+        identifier: String,
+    },
 }
 
 /// Supported credential input encodings.

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -3,10 +3,10 @@ use crate::{
     domain::{Credential, CredentialError},
     msg::CredentialInputFormat,
     services::authority,
-    state::{has_credential, record_credential, CredentialRecord},
+    state,
+    state::{has_credential, is_revoked, record_credential, CredentialRecord, CredentialTombstone},
     translation::{decode_nquads_credential, CredentialDecodingError},
 };
-
 use cosmwasm_std::{Storage, Timestamp};
 use thiserror::Error;
 
@@ -69,6 +69,13 @@ fn issue_credential_with_authority(
     Ok((credential, CredentialRecord::new(canonical_nquads)))
 }
 
+#[derive(Debug, PartialEq)]
+pub struct RevokeCredentialResult {
+    pub identifier: String,
+    pub issuer: String,
+    pub revoked_at: Timestamp,
+}
+
 #[derive(Debug, Error, PartialEq)]
 pub enum RevokeCredentialError {
     #[error("credential already revoked")]
@@ -76,6 +83,29 @@ pub enum RevokeCredentialError {
 
     #[error("credential unknown")]
     UnknownCredential,
+}
+
+pub fn revoke_credential(
+    storage: &mut dyn Storage,
+    credential_id: &str,
+    at: Timestamp,
+) -> AxoneVcResult<RevokeCredentialResult> {
+    let authority = authority(storage)?;
+    if !has_credential(storage, credential_id) {
+        return Err(RevokeCredentialError::UnknownCredential.into());
+    }
+    if is_revoked(storage, credential_id) {
+        return Err(RevokeCredentialError::CredentialAlreadyRevoked.into());
+    }
+
+    let tombstone = CredentialTombstone { revoked_at: at };
+    state::revoke_credential(storage, credential_id, &tombstone)?;
+
+    Ok(RevokeCredentialResult {
+        identifier: credential_id.to_string(),
+        issuer: authority.did().to_string(),
+        revoked_at: Default::default(),
+    })
 }
 
 #[cfg(test)]

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -98,11 +98,11 @@ pub fn revoke_credential(
     at: Timestamp,
 ) -> AxoneVcResult<RevokeCredentialResult> {
     let authority = authority(storage)?;
-    if !has_credential(storage, credential_id) {
-        return Err(RevokeCredentialError::UnknownCredential.into());
-    }
     if is_revoked(storage, credential_id) {
         return Err(RevokeCredentialError::CredentialAlreadyRevoked.into());
+    }
+    if !has_credential(storage, credential_id) {
+        return Err(RevokeCredentialError::UnknownCredential.into());
     }
 
     let tombstone = CredentialTombstone::new(at);
@@ -111,7 +111,7 @@ pub fn revoke_credential(
     Ok(RevokeCredentialResult {
         identifier: credential_id.to_string(),
         issuer: authority.did().to_string(),
-        revoked_at: Default::default(),
+        revoked_at: at,
     })
 }
 
@@ -328,6 +328,7 @@ mod tests {
     fn revoke_credential_rejects_unknown_credential() {
         let mut deps = mock_dependencies();
         let env = mock_env();
+        initialized_authority(&mut deps);
 
         let err = revoke_credential(
             deps.as_mut().storage,

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -105,7 +105,7 @@ pub fn revoke_credential(
         return Err(RevokeCredentialError::CredentialAlreadyRevoked.into());
     }
 
-    let tombstone = CredentialTombstone { revoked_at: at };
+    let tombstone = CredentialTombstone::new(at);
     state::revoke_credential(storage, credential_id, &tombstone)?;
 
     Ok(RevokeCredentialResult {
@@ -117,13 +117,14 @@ pub fn revoke_credential(
 
 #[cfg(test)]
 mod tests {
-    use super::{issue_credential, issue_credential_with_authority, IssueCredentialError};
+    use super::*;
+    use crate::state::revoke_credential;
     use crate::{
         domain::Authority, error::AxoneVcError, msg::CredentialInputFormat,
         services::initialize_authority, state::load_credential,
     };
     use bech32::{Bech32, Hrp};
-    use cosmwasm_std::{testing::mock_dependencies, Addr};
+    use cosmwasm_std::{testing::mock_dependencies, testing::mock_env, Addr};
 
     fn credential_payload(authority_did: &str, id: &str) -> Vec<u8> {
         format!(
@@ -260,5 +261,34 @@ mod tests {
         .expect_err("second submit should fail");
 
         assert_eq!(err, IssueCredentialError::CredentialAlreadyExists);
+    }
+
+    #[test]
+    fn issue_credential_with_authority_rejects_revoked() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let authority = initialized_authority(&mut deps);
+        let payload = credential_payload(authority.did(), "urn:uuid:credential-1");
+
+        issue_credential(
+            deps.as_mut().storage,
+            &payload,
+            CredentialInputFormat::NQuads,
+        )
+        .expect("first submit should succeed");
+
+        let tombstone = CredentialTombstone::new(env.block.time);
+        revoke_credential(deps.as_mut().storage, "urn:uuid:credential-1", &tombstone)
+            .expect("revocation should succeed");
+
+        let err = issue_credential_with_authority(
+            deps.as_ref().storage,
+            authority,
+            &payload,
+            CredentialInputFormat::NQuads,
+        )
+        .expect_err("second submit should fail");
+
+        assert_eq!(err, IssueCredentialError::CredentialRevoked);
     }
 }

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -69,6 +69,15 @@ fn issue_credential_with_authority(
     Ok((credential, CredentialRecord::new(canonical_nquads)))
 }
 
+#[derive(Debug, Error, PartialEq)]
+pub enum RevokeCredentialError {
+    #[error("credential already revoked")]
+    CredentialAlreadyRevoked,
+
+    #[error("credential unknown")]
+    UnknownCredential,
+}
+
 #[cfg(test)]
 mod tests {
     use super::{issue_credential, issue_credential_with_authority, IssueCredentialError};

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -24,6 +24,9 @@ pub enum IssueCredentialError {
     #[error("credential already exists")]
     CredentialAlreadyExists,
 
+    #[error("credential revoked")]
+    CredentialRevoked,
+
     #[error(transparent)]
     Decode(#[from] CredentialDecodingError),
 
@@ -64,6 +67,10 @@ fn issue_credential_with_authority(
 
     if has_credential(storage, credential.id()) {
         return Err(IssueCredentialError::CredentialAlreadyExists);
+    }
+
+    if is_revoked(storage, credential.id()) {
+        return Err(IssueCredentialError::CredentialRevoked);
     }
 
     Ok((credential, CredentialRecord::new(canonical_nquads)))

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -118,7 +118,6 @@ pub fn revoke_credential(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::revoke_credential;
     use crate::{
         domain::Authority, error::AxoneVcError, msg::CredentialInputFormat,
         services::initialize_authority, state::load_credential,
@@ -277,9 +276,12 @@ mod tests {
         )
         .expect("first submit should succeed");
 
-        let tombstone = CredentialTombstone::new(env.block.time);
-        revoke_credential(deps.as_mut().storage, "urn:uuid:credential-1", &tombstone)
-            .expect("revocation should succeed");
+        revoke_credential(
+            deps.as_mut().storage,
+            "urn:uuid:credential-1",
+            env.block.time,
+        )
+        .expect("revocation should succeed");
 
         let err = issue_credential_with_authority(
             deps.as_ref().storage,
@@ -290,5 +292,87 @@ mod tests {
         .expect_err("second submit should fail");
 
         assert_eq!(err, IssueCredentialError::CredentialRevoked);
+    }
+
+    #[test]
+    fn revoke_credential_success() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let authority = initialized_authority(&mut deps);
+        let payload = credential_payload(authority.did(), "urn:uuid:credential-1");
+
+        issue_credential(
+            deps.as_mut().storage,
+            &payload,
+            CredentialInputFormat::NQuads,
+        )
+        .expect("submit should succeed");
+
+        let res = revoke_credential(
+            deps.as_mut().storage,
+            "urn:uuid:credential-1",
+            env.block.time,
+        );
+        assert!(res.is_ok(), "revoke should succeed");
+        assert_eq!(
+            res.unwrap(),
+            RevokeCredentialResult {
+                identifier: "urn:uuid:credential-1".to_string(),
+                issuer: authority.did().to_string(),
+                revoked_at: env.block.time,
+            }
+        );
+    }
+
+    #[test]
+    fn revoke_credential_rejects_unknown_credential() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+
+        let err = revoke_credential(
+            deps.as_mut().storage,
+            "urn:uuid:credential-1",
+            env.block.time,
+        )
+        .expect_err("revocation should fail");
+
+        assert_eq!(
+            err,
+            AxoneVcError::RevokeCredential(RevokeCredentialError::UnknownCredential)
+        );
+    }
+
+    #[test]
+    fn revoke_credential_rejects_revoked_credential() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let authority = initialized_authority(&mut deps);
+        let payload = credential_payload(authority.did(), "urn:uuid:credential-1");
+
+        issue_credential(
+            deps.as_mut().storage,
+            &payload,
+            CredentialInputFormat::NQuads,
+        )
+        .expect("submit should succeed");
+
+        revoke_credential(
+            deps.as_mut().storage,
+            "urn:uuid:credential-1",
+            env.block.time,
+        )
+        .expect("first revoke should succeed");
+
+        let err = revoke_credential(
+            deps.as_mut().storage,
+            "urn:uuid:credential-1",
+            env.block.time,
+        )
+        .expect_err("second revocation should fail");
+
+        assert_eq!(
+            err,
+            AxoneVcError::RevokeCredential(RevokeCredentialError::CredentialAlreadyRevoked)
+        );
     }
 }

--- a/contracts/axone-vc/src/services/mod.rs
+++ b/contracts/axone-vc/src/services/mod.rs
@@ -2,4 +2,6 @@ mod authority;
 mod credential;
 
 pub use authority::{authority, initialize_authority};
-pub use credential::{issue_credential, IssueCredentialError};
+pub use credential::{
+    issue_credential, revoke_credential, IssueCredentialError, RevokeCredentialError,
+};

--- a/contracts/axone-vc/src/state.rs
+++ b/contracts/axone-vc/src/state.rs
@@ -2,11 +2,12 @@ use crate::domain::Authority;
 use crate::error::AxoneVcError;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{StdError, Storage};
+use cosmwasm_std::{StdError, Storage, Timestamp};
 use cw_storage_plus::{Item, Map};
 
 const AUTHORITY: Item<Authority> = Item::new("authority");
 const CREDENTIALS: Map<&str, CredentialRecord> = Map::new("credentials");
+const REVOKED_CREDENTIALS: Map<&str, CredentialTombstone> = Map::new("revoked_credentials");
 
 #[cw_serde]
 pub struct CredentialRecord {
@@ -16,6 +17,17 @@ pub struct CredentialRecord {
 impl CredentialRecord {
     pub fn new(canonical_nquads: String) -> Self {
         Self { canonical_nquads }
+    }
+}
+
+#[cw_serde]
+pub struct CredentialTombstone {
+    pub revoked_at: Timestamp,
+}
+
+impl CredentialTombstone {
+    pub fn new(revoked_at: Timestamp) -> Self {
+        Self { revoked_at }
     }
 }
 
@@ -45,6 +57,20 @@ pub fn record_credential(
     record: &CredentialRecord,
 ) -> Result<(), AxoneVcError> {
     CREDENTIALS.save(storage, credential_id, record)?;
+    Ok(())
+}
+
+pub fn is_revoked(storage: &dyn Storage, credential_id: &str) -> bool {
+    REVOKED_CREDENTIALS.has(storage, credential_id)
+}
+
+pub fn revoke_credential(
+    storage: &mut dyn Storage,
+    credential_id: &str,
+    tombstone: &CredentialTombstone,
+) -> Result<(), AxoneVcError> {
+    CREDENTIALS.remove(storage, credential_id);
+    REVOKED_CREDENTIALS.save(storage, credential_id, tombstone)?;
     Ok(())
 }
 

--- a/contracts/axone-vc/tests/integration.rs
+++ b/contracts/axone-vc/tests/integration.rs
@@ -14,6 +14,8 @@ const RESOURCE_LICENSE_ASSERTION: &str = include_str!("fixtures/resource-license
 const VC_ISSUER_PREDICATE: &str = "<https://www.w3.org/2018/credentials#issuer>";
 const SOURCE_ISSUER_DID: &str =
     "<did:pkh:cosmos:axone-1:cosmos1s7auhjsmvjpiubqwco6bxxehsqwnvepvabhbrv>";
+const RESOURCE_LICENSE_ASSERTION_ID: &str =
+    "https://credentials.axone.xyz/assertion/resource-license";
 const ABSTRACT_EVENT_TYPE: &str = "wasm-abstract";
 
 struct TestEnv<Env: CwEnv> {
@@ -94,7 +96,7 @@ fn issue_credential_emits_event() -> anyhow::Result<()> {
         response
             .event_attr_value(ABSTRACT_EVENT_TYPE, "identifier")
             .expect("Missing identifier attribute"),
-        "https://credentials.axone.xyz/assertion/resource-license"
+        RESOURCE_LICENSE_ASSERTION_ID
     );
     assert_eq!(
         response
@@ -167,6 +169,135 @@ fn issue_credential_rejects_non_host_account_sender() -> anyhow::Result<()> {
         .app
         .call_as(&unauthorized)
         .issue_credential(credential, Some(CredentialInputFormat::NQuads))
+        .expect_err("non-host sender should be rejected");
+
+    assert!(format!("{err:?}").contains("Caller is not admin"));
+
+    Ok(())
+}
+
+#[test]
+fn revoke_credential_accepts_issued_credential() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    let credential = Binary::from(resource_license_assertion_payload(&authority.did));
+
+    env.app
+        .issue_credential(credential, Some(CredentialInputFormat::NQuads))?;
+    env.app
+        .revoke_credential(RESOURCE_LICENSE_ASSERTION_ID.to_string())?;
+
+    Ok(())
+}
+
+#[test]
+fn revoke_credential_emits_event() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    let credential = Binary::from(resource_license_assertion_payload(&authority.did));
+
+    env.app
+        .issue_credential(credential, Some(CredentialInputFormat::NQuads))?;
+    let response = env
+        .app
+        .revoke_credential(RESOURCE_LICENSE_ASSERTION_ID.to_string())?;
+
+    assert_eq!(
+        response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "action")
+            .expect("Missing action attribute"),
+        "revoke_credential"
+    );
+    assert_eq!(
+        response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "identifier")
+            .expect("Missing identifier attribute"),
+        RESOURCE_LICENSE_ASSERTION_ID
+    );
+    assert_eq!(
+        response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "issuer")
+            .expect("Missing issuer attribute"),
+        authority.did
+    );
+    assert!(response
+        .event_attr_value(ABSTRACT_EVENT_TYPE, "revoked_at")
+        .expect("Missing revoked_at attribute")
+        .contains('.'));
+
+    Ok(())
+}
+
+#[test]
+fn revoke_credential_rejects_unknown_credential() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+
+    let err = env
+        .app
+        .revoke_credential(RESOURCE_LICENSE_ASSERTION_ID.to_string())
+        .expect_err("unknown credential should be rejected");
+
+    assert!(format!("{err:?}").contains("credential unknown"), "{err:?}");
+
+    Ok(())
+}
+
+#[test]
+fn revoke_credential_rejects_duplicates() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    let credential = Binary::from(resource_license_assertion_payload(&authority.did));
+
+    env.app
+        .issue_credential(credential, Some(CredentialInputFormat::NQuads))?;
+    env.app
+        .revoke_credential(RESOURCE_LICENSE_ASSERTION_ID.to_string())?;
+    let err = env
+        .app
+        .revoke_credential(RESOURCE_LICENSE_ASSERTION_ID.to_string())
+        .expect_err("duplicate revocation should fail");
+
+    assert!(
+        format!("{err:?}").contains("credential already revoked"),
+        "{err:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn revoke_credential_prevents_reissuing_same_identifier() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    let credential = Binary::from(resource_license_assertion_payload(&authority.did));
+
+    env.app
+        .issue_credential(credential.clone(), Some(CredentialInputFormat::NQuads))?;
+    env.app
+        .revoke_credential(RESOURCE_LICENSE_ASSERTION_ID.to_string())?;
+    let err = env
+        .app
+        .issue_credential(credential, Some(CredentialInputFormat::NQuads))
+        .expect_err("revoked credential identifier should not be reusable");
+
+    assert!(format!("{err:?}").contains("credential revoked"), "{err:?}");
+
+    Ok(())
+}
+
+#[test]
+fn revoke_credential_rejects_non_host_account_sender() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    let credential = Binary::from(resource_license_assertion_payload(&authority.did));
+    let unauthorized = env.app.environment().addr_make("unauthorized");
+
+    env.app
+        .issue_credential(credential, Some(CredentialInputFormat::NQuads))?;
+    let err = env
+        .app
+        .call_as(&unauthorized)
+        .revoke_credential(RESOURCE_LICENSE_ASSERTION_ID.to_string())
         .expect_err("non-host sender should be rejected");
 
     assert!(format!("{err:?}").contains("Caller is not admin"));

--- a/docs/axone-vc.md
+++ b/docs/axone-vc.md
@@ -61,6 +61,21 @@ Issuance fails if the payload format is not supported, if the credential represe
 | `issue_credential.credential` | _(Required.) _ **[Binary](#binary)**. Serialized credential payload.<br /><br />The expected binary encoding and semantic representation are determined by the `format` field. |
 | `issue_credential.format`     | **[CredentialInputFormat](#credentialinputformat)\|null**. Encoding used by the submitted credential payload.<br /><br />Defaults to `n_quads` when omitted.                   |
 
+### ExecuteMsg::revoke_credential
+
+Revoke a verifiable credential from this authority.
+
+Only the app authority is allowed to call this message.
+
+The revocation is terminal, the same identifier cannot be issued again.
+
+Revocation fails if the identifier is unknown or already revoked.
+
+| parameter                      | description                                                     |
+| ------------------------------ | --------------------------------------------------------------- |
+| `revoke_credential`            | _(Required.) _ **object**.                                      |
+| `revoke_credential.identifier` | _(Required.) _ **string**. The credential identifier to revoke. |
+
 ## QueryMsg
 
 Query messages.
@@ -136,4 +151,4 @@ N-Quads extends N-Triples to represent RDF datasets by allowing an optional four
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`d6a66ab44dc4de1f`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`a466d08b9b644044`)_


### PR DESCRIPTION
Implement #823  by adding the `RevokeCredential` execute message to the `axone-vc` smart contract.

## Details

Only the authority can perform the `RevokeCredential ` execute message.

The new `REVOKED_CREDENTIALS` store has been introduced to store revocation tombstones. It is used to prevent the re-issuance of a revoked credential.