### PR TITLE
✨ feat(vc): introduce VerifyCredential query

### DIFF
--- a/contracts/axone-gov/src/bin/install.rs
+++ b/contracts/axone-gov/src/bin/install.rs
@@ -35,7 +35,7 @@ fn install(
 
         seed_abstract_addresses(&chain, &network, &rt)?;
 
-        let abstract_client: AbstractClient<Daemon> = AbstractClient::new(chain.clone())?;
+        let abstract_client: AbstractClient<Daemon> = AbstractClient::new(chain)?;
 
         let account = abstract_client.fetch_account(account_id.clone())?;
 

--- a/contracts/axone-vc/src/domain/credential.rs
+++ b/contracts/axone-vc/src/domain/credential.rs
@@ -29,6 +29,9 @@ pub enum CredentialError {
 
     #[error("credential is not a verifiable credential")]
     NotVerifiableCredential,
+
+    #[error("credential validity interval is invalid")]
+    InvalidValidityInterval,
 }
 
 #[derive(Clone, CopyGetters, Debug, Getters, PartialEq)]
@@ -39,6 +42,10 @@ pub struct Credential {
     issuer: Uri,
     #[getset(get_copy = "pub")]
     issuance_date: Timestamp,
+    #[getset(get_copy = "pub")]
+    valid_from: Option<Timestamp>,
+    #[getset(get_copy = "pub")]
+    valid_until: Option<Timestamp>,
     #[getset(get = "pub")]
     subject_id: Uri,
     #[getset(get = "pub")]
@@ -61,6 +68,8 @@ impl TryFrom<(DecodedCredential, Authority)> for Credential {
         let issuance_date = decoded
             .issuance_date()
             .ok_or(CredentialError::MissingIssuanceDate)?;
+        let valid_from = *decoded.valid_from();
+        let valid_until = *decoded.valid_until();
         let subject_id = match decoded.subject_id() {
             DecodedUri::Uri(uri) => uri.clone(),
             DecodedUri::Missing | DecodedUri::Invalid => {
@@ -81,10 +90,16 @@ impl TryFrom<(DecodedCredential, Authority)> for Credential {
             return Err(CredentialError::NotVerifiableCredential);
         }
 
+        if matches!((valid_from, valid_until), (Some(from), Some(until)) if from >= until) {
+            return Err(CredentialError::InvalidValidityInterval);
+        }
+
         Ok(Self {
             id,
             issuer,
             issuance_date,
+            valid_from,
+            valid_until,
             subject_id,
             types,
         })
@@ -276,5 +291,26 @@ mod tests {
             Credential::try_from((decoded, authority())).expect_err("missing vc type should fail");
 
         assert_eq!(err, CredentialError::NotVerifiableCredential);
+    }
+
+    #[test]
+    fn try_from_rejects_inverted_validity_interval() {
+        let decoded = DecodedCredential::new(
+            Some("urn:uuid:credential-1".to_string()),
+            DecodedUri::Uri(AUTHORITY_DID.to_string()),
+            Some(Timestamp::from_seconds(1_735_689_600)),
+            DecodedUri::Uri("did:example:subject".to_string()),
+            vec![VC_TYPE.to_string()],
+            String::new(),
+        )
+        .with_validity(
+            Some(Timestamp::from_seconds(20)),
+            Some(Timestamp::from_seconds(10)),
+        );
+
+        let err = Credential::try_from((decoded, authority()))
+            .expect_err("inverted validity interval should fail");
+
+        assert_eq!(err, CredentialError::InvalidValidityInterval);
     }
 }

--- a/contracts/axone-vc/src/handlers/query.rs
+++ b/contracts/axone-vc/src/handlers/query.rs
@@ -1,7 +1,7 @@
 use crate::{
     contract::{AxoneVc, AxoneVcResult},
-    msg::{AuthorityResponse, AxoneVcQueryMsg},
-    services::authority,
+    msg::{AuthorityResponse, AxoneVcQueryMsg, VerifyCredentialResponse},
+    services::{authority, verify_credential},
 };
 
 use cosmwasm_std::{to_json_binary, Binary, Deps, Env};
@@ -14,8 +14,24 @@ pub fn query_handler(
 ) -> AxoneVcResult<Binary> {
     match msg {
         AxoneVcQueryMsg::Authority {} => to_json_binary(&query_authority(deps)?),
+        AxoneVcQueryMsg::VerifyCredential {
+            identifier,
+            valid_at,
+        } => to_json_binary(&query_verify_credential(deps, identifier, valid_at)?),
     }
     .map_err(Into::into)
+}
+
+fn query_verify_credential(
+    deps: Deps<'_>,
+    identifier: String,
+    valid_at: Option<cosmwasm_std::Timestamp>,
+) -> AxoneVcResult<VerifyCredentialResponse> {
+    let result = verify_credential(deps.storage, &identifier, valid_at)?;
+    Ok(VerifyCredentialResponse {
+        exists: result.exists,
+        valid: result.valid,
+    })
 }
 
 fn query_authority(deps: Deps<'_>) -> AxoneVcResult<AuthorityResponse> {

--- a/contracts/axone-vc/src/msg.rs
+++ b/contracts/axone-vc/src/msg.rs
@@ -32,6 +32,8 @@ pub enum AxoneVcExecuteMsg {
     /// - an issuance date
     /// - a subject identifier
     /// - at least one type, including `VerifiableCredential`
+    /// - optional `validFrom` and `validUntil` claims, when present, encoded as
+    ///   `xsd:dateTimeStamp` instants with `validFrom < validUntil`
     ///
     /// The submitted payload may omit the issuer. In that case, the contract
     /// treats the credential as issued by its authority DID.

--- a/contracts/axone-vc/src/msg.rs
+++ b/contracts/axone-vc/src/msg.rs
@@ -1,7 +1,7 @@
-use crate::contract::AxoneVc;
+use crate::{contract::AxoneVc, domain::Uri};
 
 use cosmwasm_schema::QueryResponses;
-use cosmwasm_std::Binary;
+use cosmwasm_std::{Binary, Timestamp};
 
 abstract_app::app_msg_types!(AxoneVc, AxoneVcExecuteMsg, AxoneVcQueryMsg);
 
@@ -105,6 +105,20 @@ pub enum AxoneVcQueryMsg {
     /// `did:pkh:cosmos:<chain_id>:cosmos1...`
     #[returns(AuthorityResponse)]
     Authority {},
+
+    /// Check whether a credential is active and, optionally, valid at a given instant.
+    ///
+    /// Revoked credentials are not part of the active credential set and therefore
+    /// return the same result as unknown identifiers.
+    #[returns(VerifyCredentialResponse)]
+    VerifyCredential {
+        /// Identifier of the credential to check.
+        identifier: Uri,
+        /// Optional instant at which to evaluate the credential validity interval.
+        ///
+        /// When omitted, every active credential is considered valid.
+        valid_at: Option<Timestamp>,
+    },
 }
 
 /// Response returned by `AxoneVcQueryMsg::Authority`.
@@ -120,4 +134,15 @@ pub struct AuthorityResponse {
     ///
     /// `did:pkh:cosmos:<chain_id>:cosmos1...`
     pub did: String,
+}
+
+/// Response returned by `AxoneVcQueryMsg::VerifyCredential`.
+#[cosmwasm_schema::cw_serde]
+pub struct VerifyCredentialResponse {
+    /// Whether the identifier belongs to an active credential.
+    pub exists: bool,
+    /// Whether the active credential is valid for the requested instant.
+    ///
+    /// This is equal to `exists` when no instant was requested.
+    pub valid: bool,
 }

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -4,7 +4,10 @@ use crate::{
     msg::CredentialInputFormat,
     services::authority,
     state,
-    state::{has_credential, is_revoked, record_credential, CredentialRecord, CredentialTombstone},
+    state::{
+        credential, has_credential, is_revoked, record_credential, CredentialRecord,
+        CredentialTombstone,
+    },
     translation::{decode_nquads_credential, CredentialDecodingError},
 };
 use cosmwasm_std::{Storage, Timestamp};
@@ -63,6 +66,8 @@ fn issue_credential_with_authority(
         CredentialInputFormat::NQuads => decode_nquads_credential(input)?,
     };
     let canonical_nquads = decoded.canonical_nquads().clone();
+    let valid_from = *decoded.valid_from();
+    let valid_until = *decoded.valid_until();
     let credential = Credential::try_from((decoded, authority))?;
 
     if has_credential(storage, credential.id()) {
@@ -73,7 +78,39 @@ fn issue_credential_with_authority(
         return Err(IssueCredentialError::CredentialRevoked);
     }
 
-    Ok((credential, CredentialRecord::new(canonical_nquads)))
+    Ok((
+        credential,
+        CredentialRecord::new(canonical_nquads, valid_from, valid_until),
+    ))
+}
+
+#[derive(Debug, PartialEq)]
+pub struct VerifyCredentialResult {
+    pub exists: bool,
+    pub valid: bool,
+}
+
+pub fn verify_credential(
+    storage: &dyn Storage,
+    credential_id: &str,
+    valid_at: Option<Timestamp>,
+) -> AxoneVcResult<VerifyCredentialResult> {
+    let Some(record) = credential(storage, credential_id)? else {
+        return Ok(VerifyCredentialResult {
+            exists: false,
+            valid: false,
+        });
+    };
+
+    let valid = valid_at.is_none_or(|at| {
+        record.valid_from.is_none_or(|from| from <= at)
+            && record.valid_until.is_none_or(|until| at < until)
+    });
+
+    Ok(VerifyCredentialResult {
+        exists: true,
+        valid,
+    })
 }
 
 #[derive(Debug, PartialEq)]
@@ -121,6 +158,7 @@ mod tests {
     use crate::{
         domain::Authority, error::AxoneVcError, msg::CredentialInputFormat,
         services::initialize_authority, state::load_credential,
+        translation::CredentialDecodingError,
     };
     use bech32::{Bech32, Hrp};
     use cosmwasm_std::{testing::mock_dependencies, testing::mock_env, Addr};
@@ -140,6 +178,24 @@ mod tests {
         format!(
             r#"<{id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
 <{id}> <https://www.w3.org/2018/credentials#issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<{id}> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:subject> .
+"#
+        )
+        .into_bytes()
+    }
+
+    fn credential_payload_with_validity(
+        authority_did: &str,
+        id: &str,
+        valid_from: &str,
+        valid_until: &str,
+    ) -> Vec<u8> {
+        format!(
+            r#"<{id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{id}> <https://www.w3.org/2018/credentials#issuer> <{authority_did}> .
+<{id}> <https://www.w3.org/2018/credentials#issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<{id}> <https://www.w3.org/2018/credentials#validFrom> "{valid_from}"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+<{id}> <https://www.w3.org/2018/credentials#validUntil> "{valid_until}"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
 <{id}> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:subject> .
 "#
         )
@@ -194,6 +250,8 @@ mod tests {
             .expect("credential should be persisted");
         assert!(record.canonical_nquads.contains(credential_id));
         assert!(record.canonical_nquads.contains(authority.did()));
+        assert_eq!(record.valid_from, None);
+        assert_eq!(record.valid_until, None);
     }
 
     #[test]
@@ -292,6 +350,130 @@ mod tests {
         .expect_err("second submit should fail");
 
         assert_eq!(err, IssueCredentialError::CredentialRevoked);
+    }
+
+    #[test]
+    fn issue_credential_persists_validity_interval_and_verifies_boundaries() {
+        let mut deps = mock_dependencies();
+        let authority = initialized_authority(&mut deps);
+        let credential_id = "urn:uuid:credential-validity";
+        let valid_from = Timestamp::from_seconds(10);
+        let valid_until = Timestamp::from_seconds(20);
+
+        issue_credential(
+            deps.as_mut().storage,
+            &credential_payload_with_validity(
+                authority.did(),
+                credential_id,
+                "1970-01-01T00:00:10Z",
+                "1970-01-01T00:00:20Z",
+            ),
+            CredentialInputFormat::NQuads,
+        )
+        .expect("credential should issue");
+
+        let record = load_credential(deps.as_ref().storage, credential_id)
+            .expect("credential should be stored");
+        assert_eq!(record.valid_from, Some(valid_from));
+        assert_eq!(record.valid_until, Some(valid_until));
+
+        let cases = [
+            (None, true),
+            (Some(Timestamp::from_seconds(9)), false),
+            (Some(valid_from), true),
+            (Some(Timestamp::from_seconds(19)), true),
+            (Some(valid_until), false),
+        ];
+        for (at, expected_valid) in cases {
+            assert_eq!(
+                verify_credential(deps.as_ref().storage, credential_id, at)
+                    .expect("verification should succeed"),
+                VerifyCredentialResult {
+                    exists: true,
+                    valid: expected_valid,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn issue_credential_rejects_invalid_validity_claims() {
+        let mut deps = mock_dependencies();
+        let authority = initialized_authority(&mut deps);
+
+        let wrong_type = String::from_utf8(credential_payload_with_validity(
+            authority.did(),
+            "urn:uuid:wrong-validity-type",
+            "1970-01-01T00:00:10Z",
+            "1970-01-01T00:00:20Z",
+        ))
+        .expect("test payload should be UTF-8")
+        .replace("#dateTimeStamp", "#dateTime");
+        let err = issue_credential(
+            deps.as_mut().storage,
+            wrong_type.as_bytes(),
+            CredentialInputFormat::NQuads,
+        )
+        .expect_err("non-dateTimeStamp validity claims should fail");
+        assert_eq!(
+            err,
+            AxoneVcError::IssueCredential(IssueCredentialError::Decode(
+                CredentialDecodingError::InvalidDataset
+            ))
+        );
+
+        let err = issue_credential(
+            deps.as_mut().storage,
+            &credential_payload_with_validity(
+                authority.did(),
+                "urn:uuid:inverted-validity",
+                "1970-01-01T00:00:20Z",
+                "1970-01-01T00:00:10Z",
+            ),
+            CredentialInputFormat::NQuads,
+        )
+        .expect_err("inverted validity interval should fail");
+        assert_eq!(
+            err,
+            AxoneVcError::IssueCredential(IssueCredentialError::Domain(
+                CredentialError::InvalidValidityInterval
+            ))
+        );
+    }
+
+    #[test]
+    fn verify_credential_treats_unknown_and_revoked_credentials_as_absent() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let authority = initialized_authority(&mut deps);
+        let credential_id = "urn:uuid:credential-1";
+
+        assert_eq!(
+            verify_credential(deps.as_ref().storage, credential_id, None)
+                .expect("verification should succeed"),
+            VerifyCredentialResult {
+                exists: false,
+                valid: false,
+            }
+        );
+
+        issue_credential(
+            deps.as_mut().storage,
+            &credential_payload(authority.did(), credential_id),
+            CredentialInputFormat::NQuads,
+        )
+        .expect("credential should issue");
+        revoke_credential(deps.as_mut().storage, credential_id, env.block.time)
+            .expect("credential should revoke");
+
+        assert_eq!(
+            verify_credential(deps.as_ref().storage, credential_id, None)
+                .expect("verification should succeed"),
+            VerifyCredentialResult {
+                exists: false,
+                valid: false,
+            }
+        );
     }
 
     #[test]

--- a/contracts/axone-vc/src/services/mod.rs
+++ b/contracts/axone-vc/src/services/mod.rs
@@ -3,5 +3,6 @@ mod credential;
 
 pub use authority::{authority, initialize_authority};
 pub use credential::{
-    issue_credential, revoke_credential, IssueCredentialError, RevokeCredentialError,
+    issue_credential, revoke_credential, verify_credential, IssueCredentialError,
+    RevokeCredentialError,
 };

--- a/contracts/axone-vc/src/state.rs
+++ b/contracts/axone-vc/src/state.rs
@@ -94,6 +94,15 @@ pub fn revoke_credential(
 }
 
 #[cfg(test)]
+pub fn load_credential(
+    storage: &dyn Storage,
+    credential_id: &str,
+) -> Result<CredentialRecord, AxoneVcError> {
+    credential(storage, credential_id)?
+        .ok_or_else(|| StdError::not_found("CredentialRecord").into())
+}
+
+#[cfg(test)]
 mod tests {
     use super::CredentialRecord;
     use cosmwasm_std::from_json;
@@ -106,12 +115,4 @@ mod tests {
         assert_eq!(record.valid_from, None);
         assert_eq!(record.valid_until, None);
     }
-}
-
-#[cfg(test)]
-pub fn load_credential(
-    storage: &dyn Storage,
-    credential_id: &str,
-) -> Result<CredentialRecord, AxoneVcError> {
-    Ok(CREDENTIALS.load(storage, credential_id)?)
 }

--- a/contracts/axone-vc/src/state.rs
+++ b/contracts/axone-vc/src/state.rs
@@ -12,11 +12,23 @@ const REVOKED_CREDENTIALS: Map<&str, CredentialTombstone> = Map::new("revoked_cr
 #[cw_serde]
 pub struct CredentialRecord {
     pub canonical_nquads: String,
+    #[serde(default)]
+    pub valid_from: Option<Timestamp>,
+    #[serde(default)]
+    pub valid_until: Option<Timestamp>,
 }
 
 impl CredentialRecord {
-    pub fn new(canonical_nquads: String) -> Self {
-        Self { canonical_nquads }
+    pub fn new(
+        canonical_nquads: String,
+        valid_from: Option<Timestamp>,
+        valid_until: Option<Timestamp>,
+    ) -> Self {
+        Self {
+            canonical_nquads,
+            valid_from,
+            valid_until,
+        }
     }
 }
 
@@ -51,6 +63,13 @@ pub fn has_credential(storage: &dyn Storage, credential_id: &str) -> bool {
     CREDENTIALS.has(storage, credential_id)
 }
 
+pub fn credential(
+    storage: &dyn Storage,
+    credential_id: &str,
+) -> Result<Option<CredentialRecord>, AxoneVcError> {
+    Ok(CREDENTIALS.may_load(storage, credential_id)?)
+}
+
 pub fn record_credential(
     storage: &mut dyn Storage,
     credential_id: &str,
@@ -72,6 +91,21 @@ pub fn revoke_credential(
     CREDENTIALS.remove(storage, credential_id);
     REVOKED_CREDENTIALS.save(storage, credential_id, tombstone)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CredentialRecord;
+    use cosmwasm_std::from_json;
+
+    #[test]
+    fn credential_record_without_validity_bounds_deserializes_as_unbounded() {
+        let record: CredentialRecord = from_json(br#"{"canonical_nquads":"<credential>"}"#)
+            .expect("legacy credential record should deserialize");
+
+        assert_eq!(record.valid_from, None);
+        assert_eq!(record.valid_until, None);
+    }
 }
 
 #[cfg(test)]

--- a/contracts/axone-vc/src/translation/credential_rdf.rs
+++ b/contracts/axone-vc/src/translation/credential_rdf.rs
@@ -105,13 +105,11 @@ pub fn decode_nquads_credential(
     let quads = parse_nquads_quads(utf8.as_bytes())?;
     let dataset = Dataset::from_iter(quads.iter().cloned());
     let credential_subject = find_credential_subject(&dataset)?;
-    ensure_single_validity_bound(&quads, &credential_subject, VC_VALID_FROM)?;
-    ensure_single_validity_bound(&quads, &credential_subject, VC_VALID_UNTIL)?;
     let id = subject_to_identifier(&credential_subject);
     let issuer = extract_issuer(&dataset, &credential_subject)?;
     let issuance_date = extract_issuance_date(&dataset, &credential_subject)?;
-    let valid_from = extract_validity_bound(&dataset, &credential_subject, VC_VALID_FROM)?;
-    let valid_until = extract_validity_bound(&dataset, &credential_subject, VC_VALID_UNTIL)?;
+    let valid_from = extract_validity_bound(&quads, &credential_subject, VC_VALID_FROM)?;
+    let valid_until = extract_validity_bound(&quads, &credential_subject, VC_VALID_UNTIL)?;
     let subject_id = extract_subject_id(&dataset, &credential_subject)?;
     let types = extract_types(&dataset, &credential_subject);
     let canonical_nquads = canonicalize_dataset(&dataset)?;
@@ -213,14 +211,16 @@ fn parse_issuance_date(literal: &Literal) -> Result<Timestamp, CredentialDecodin
 }
 
 fn extract_validity_bound(
-    dataset: &Dataset,
+    quads: &[Quad],
     credential_subject: &Subject,
     predicate: NamedNodeRef<'_>,
 ) -> Result<Option<Timestamp>, CredentialDecodingError> {
-    let objects: Vec<Term> = dataset
-        .quads_for_subject(credential_subject.as_ref())
-        .filter(|quad| quad.predicate == predicate)
-        .map(|quad| quad.object.into_owned())
+    let objects: Vec<&Term> = quads
+        .iter()
+        .filter(|quad| {
+            quad.subject.as_ref() == credential_subject.as_ref() && quad.predicate == predicate
+        })
+        .map(|quad| &quad.object)
         .collect();
 
     match objects.as_slice() {
@@ -228,25 +228,6 @@ fn extract_validity_bound(
         [Term::Literal(literal)] => parse_validity_bound(literal).map(Some),
         _ => Err(CredentialDecodingError::InvalidDataset),
     }
-}
-
-fn ensure_single_validity_bound(
-    quads: &[Quad],
-    credential_subject: &Subject,
-    predicate: NamedNodeRef<'_>,
-) -> Result<(), CredentialDecodingError> {
-    let count = quads
-        .iter()
-        .filter(|quad| {
-            quad.subject.as_ref() == credential_subject.as_ref() && quad.predicate == predicate
-        })
-        .count();
-
-    if count > 1 {
-        return Err(CredentialDecodingError::InvalidDataset);
-    }
-
-    Ok(())
 }
 
 fn parse_validity_bound(literal: &Literal) -> Result<Timestamp, CredentialDecodingError> {
@@ -314,8 +295,8 @@ mod tests {
     use super::{
         decode_nquads_credential, extract_issuance_date, extract_issuer, extract_subject_id,
         extract_validity_bound, find_credential_subject, map_canonicalization_error,
-        parse_issuance_date, parse_nquads, parse_validity_bound, subject_to_identifier,
-        CredentialDecodingError, DecodedUri, VC_ISSUER, VC_VALID_FROM,
+        parse_issuance_date, parse_nquads, parse_nquads_quads, parse_validity_bound,
+        subject_to_identifier, CredentialDecodingError, DecodedUri, VC_ISSUER, VC_VALID_FROM,
     };
     use cosmwasm_std::Timestamp;
     use oxrdf::{BlankNode, Literal, NamedNodeRef, Subject};
@@ -651,16 +632,17 @@ mod tests {
 
     #[test]
     fn extract_validity_bound_accepts_date_time_stamp() {
-        let dataset = parsed_dataset(
+        let quads = parse_nquads_quads(
             format!(
                 r#"<{CREDENTIAL_ID}> <{VC_NAMESPACE}validFrom> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
 "#
             )
             .as_bytes(),
-        );
+        )
+        .expect("quads should parse");
 
         let bound = extract_validity_bound(
-            &dataset,
+            &quads,
             &Subject::NamedNode(NamedNodeRef::new_unchecked(CREDENTIAL_ID).into_owned()),
             VC_VALID_FROM,
         )
@@ -671,17 +653,18 @@ mod tests {
 
     #[test]
     fn extract_validity_bound_rejects_duplicate_claims() {
-        let dataset = parsed_dataset(
+        let quads = parse_nquads_quads(
             format!(
                 r#"<{CREDENTIAL_ID}> <{VC_NAMESPACE}validFrom> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
 <{CREDENTIAL_ID}> <{VC_NAMESPACE}validFrom> "2025-01-02T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
 "#
             )
             .as_bytes(),
-        );
+        )
+        .expect("quads should parse");
 
         let err = extract_validity_bound(
-            &dataset,
+            &quads,
             &Subject::NamedNode(NamedNodeRef::new_unchecked(CREDENTIAL_ID).into_owned()),
             VC_VALID_FROM,
         )

--- a/contracts/axone-vc/src/translation/credential_rdf.rs
+++ b/contracts/axone-vc/src/translation/credential_rdf.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::Timestamp;
 use getset::Getters;
 use oxrdf::{
     vocab::{rdf, xsd},
-    Dataset, Literal, NamedNodeRef, Subject, Term,
+    Dataset, Literal, NamedNodeRef, Quad, Subject, Term,
 };
 use oxttl::NQuadsParser;
 use rdf_canon::canonicalize;
@@ -14,6 +14,10 @@ const VC_ISSUER: NamedNodeRef<'static> =
     NamedNodeRef::new_unchecked("https://www.w3.org/2018/credentials#issuer");
 const VC_ISSUANCE_DATE: NamedNodeRef<'static> =
     NamedNodeRef::new_unchecked("https://www.w3.org/2018/credentials#issuanceDate");
+const VC_VALID_FROM: NamedNodeRef<'static> =
+    NamedNodeRef::new_unchecked("https://www.w3.org/2018/credentials#validFrom");
+const VC_VALID_UNTIL: NamedNodeRef<'static> =
+    NamedNodeRef::new_unchecked("https://www.w3.org/2018/credentials#validUntil");
 const VC_CREDENTIAL_SUBJECT: NamedNodeRef<'static> =
     NamedNodeRef::new_unchecked("https://www.w3.org/2018/credentials#credentialSubject");
 
@@ -51,6 +55,10 @@ pub struct DecodedCredential {
     #[getset(get = "pub(crate)")]
     issuance_date: Option<Timestamp>,
     #[getset(get = "pub(crate)")]
+    valid_from: Option<Timestamp>,
+    #[getset(get = "pub(crate)")]
+    valid_until: Option<Timestamp>,
+    #[getset(get = "pub(crate)")]
     subject_id: DecodedUri,
     #[getset(get = "pub(crate)")]
     types: Vec<String>,
@@ -71,10 +79,22 @@ impl DecodedCredential {
             id,
             issuer,
             issuance_date,
+            valid_from: None,
+            valid_until: None,
             subject_id,
             types,
             canonical_nquads,
         }
+    }
+
+    pub(crate) fn with_validity(
+        mut self,
+        valid_from: Option<Timestamp>,
+        valid_until: Option<Timestamp>,
+    ) -> Self {
+        self.valid_from = valid_from;
+        self.valid_until = valid_until;
+        self
     }
 }
 
@@ -82,11 +102,16 @@ pub fn decode_nquads_credential(
     input: &[u8],
 ) -> Result<DecodedCredential, CredentialDecodingError> {
     let utf8 = str::from_utf8(input).map_err(|_| CredentialDecodingError::InvalidUtf8)?;
-    let dataset = parse_nquads(utf8.as_bytes())?;
+    let quads = parse_nquads_quads(utf8.as_bytes())?;
+    let dataset = Dataset::from_iter(quads.iter().cloned());
     let credential_subject = find_credential_subject(&dataset)?;
+    ensure_single_validity_bound(&quads, &credential_subject, VC_VALID_FROM)?;
+    ensure_single_validity_bound(&quads, &credential_subject, VC_VALID_UNTIL)?;
     let id = subject_to_identifier(&credential_subject);
     let issuer = extract_issuer(&dataset, &credential_subject)?;
     let issuance_date = extract_issuance_date(&dataset, &credential_subject)?;
+    let valid_from = extract_validity_bound(&dataset, &credential_subject, VC_VALID_FROM)?;
+    let valid_until = extract_validity_bound(&dataset, &credential_subject, VC_VALID_UNTIL)?;
     let subject_id = extract_subject_id(&dataset, &credential_subject)?;
     let types = extract_types(&dataset, &credential_subject);
     let canonical_nquads = canonicalize_dataset(&dataset)?;
@@ -98,24 +123,34 @@ pub fn decode_nquads_credential(
         subject_id,
         types,
         canonical_nquads,
-    ))
+    )
+    .with_validity(valid_from, valid_until))
 }
 
+#[cfg(test)]
 fn parse_nquads(input: &[u8]) -> Result<Dataset, CredentialDecodingError> {
-    let quads = NQuadsParser::new()
+    Ok(Dataset::from_iter(parse_nquads_quads(input)?))
+}
+
+fn parse_nquads_quads(input: &[u8]) -> Result<Vec<Quad>, CredentialDecodingError> {
+    NQuadsParser::new()
         .for_slice(input)
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|_| CredentialDecodingError::InvalidNQuads)?;
-
-    Ok(Dataset::from_iter(quads))
+        .map_err(|_| CredentialDecodingError::InvalidNQuads)
 }
 
 fn find_credential_subject(dataset: &Dataset) -> Result<Subject, CredentialDecodingError> {
-    let candidate_subjects: HashSet<Subject> = [VC_ISSUER, VC_ISSUANCE_DATE, VC_CREDENTIAL_SUBJECT]
-        .into_iter()
-        .flat_map(|predicate| dataset.quads_for_predicate(predicate))
-        .map(|quad| quad.subject.into_owned())
-        .collect();
+    let candidate_subjects: HashSet<Subject> = [
+        VC_ISSUER,
+        VC_ISSUANCE_DATE,
+        VC_VALID_FROM,
+        VC_VALID_UNTIL,
+        VC_CREDENTIAL_SUBJECT,
+    ]
+    .into_iter()
+    .flat_map(|predicate| dataset.quads_for_predicate(predicate))
+    .map(|quad| quad.subject.into_owned())
+    .collect();
 
     let mut subjects = candidate_subjects.into_iter();
     let subject = subjects
@@ -177,6 +212,56 @@ fn parse_issuance_date(literal: &Literal) -> Result<Timestamp, CredentialDecodin
     Ok(Timestamp::from_nanos(nanos))
 }
 
+fn extract_validity_bound(
+    dataset: &Dataset,
+    credential_subject: &Subject,
+    predicate: NamedNodeRef<'_>,
+) -> Result<Option<Timestamp>, CredentialDecodingError> {
+    let objects: Vec<Term> = dataset
+        .quads_for_subject(credential_subject.as_ref())
+        .filter(|quad| quad.predicate == predicate)
+        .map(|quad| quad.object.into_owned())
+        .collect();
+
+    match objects.as_slice() {
+        [] => Ok(None),
+        [Term::Literal(literal)] => parse_validity_bound(literal).map(Some),
+        _ => Err(CredentialDecodingError::InvalidDataset),
+    }
+}
+
+fn ensure_single_validity_bound(
+    quads: &[Quad],
+    credential_subject: &Subject,
+    predicate: NamedNodeRef<'_>,
+) -> Result<(), CredentialDecodingError> {
+    let count = quads
+        .iter()
+        .filter(|quad| {
+            quad.subject.as_ref() == credential_subject.as_ref() && quad.predicate == predicate
+        })
+        .count();
+
+    if count > 1 {
+        return Err(CredentialDecodingError::InvalidDataset);
+    }
+
+    Ok(())
+}
+
+fn parse_validity_bound(literal: &Literal) -> Result<Timestamp, CredentialDecodingError> {
+    if literal.datatype() != xsd::DATE_TIME_STAMP {
+        return Err(CredentialDecodingError::InvalidDataset);
+    }
+
+    let datetime = OffsetDateTime::parse(literal.value(), &Rfc3339)
+        .map_err(|_| CredentialDecodingError::InvalidDataset)?;
+    let nanos = u64::try_from(datetime.unix_timestamp_nanos())
+        .map_err(|_| CredentialDecodingError::InvalidDataset)?;
+
+    Ok(Timestamp::from_nanos(nanos))
+}
+
 fn extract_subject_id(
     dataset: &Dataset,
     credential_subject: &Subject,
@@ -228,9 +313,11 @@ fn map_canonicalization_error(_: rdf_canon::CanonicalizationError) -> Credential
 mod tests {
     use super::{
         decode_nquads_credential, extract_issuance_date, extract_issuer, extract_subject_id,
-        find_credential_subject, map_canonicalization_error, parse_issuance_date, parse_nquads,
-        subject_to_identifier, CredentialDecodingError, DecodedUri, VC_ISSUER,
+        extract_validity_bound, find_credential_subject, map_canonicalization_error,
+        parse_issuance_date, parse_nquads, parse_validity_bound, subject_to_identifier,
+        CredentialDecodingError, DecodedUri, VC_ISSUER, VC_VALID_FROM,
     };
+    use cosmwasm_std::Timestamp;
     use oxrdf::{BlankNode, Literal, NamedNodeRef, Subject};
 
     const AUTHORITY_DID: &str = "did:pkh:cosmos:axone-localnet-1:cosmos1authority";
@@ -560,6 +647,86 @@ mod tests {
         let err = parse_issuance_date(&literal).expect_err("negative timestamps should fail");
 
         assert_eq!(err, CredentialDecodingError::InvalidDataset);
+    }
+
+    #[test]
+    fn extract_validity_bound_accepts_date_time_stamp() {
+        let dataset = parsed_dataset(
+            format!(
+                r#"<{CREDENTIAL_ID}> <{VC_NAMESPACE}validFrom> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+"#
+            )
+            .as_bytes(),
+        );
+
+        let bound = extract_validity_bound(
+            &dataset,
+            &Subject::NamedNode(NamedNodeRef::new_unchecked(CREDENTIAL_ID).into_owned()),
+            VC_VALID_FROM,
+        )
+        .expect("validity bound should decode");
+
+        assert_eq!(bound, Some(Timestamp::from_seconds(1_735_689_600)));
+    }
+
+    #[test]
+    fn extract_validity_bound_rejects_duplicate_claims() {
+        let dataset = parsed_dataset(
+            format!(
+                r#"<{CREDENTIAL_ID}> <{VC_NAMESPACE}validFrom> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}validFrom> "2025-01-02T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+"#
+            )
+            .as_bytes(),
+        );
+
+        let err = extract_validity_bound(
+            &dataset,
+            &Subject::NamedNode(NamedNodeRef::new_unchecked(CREDENTIAL_ID).into_owned()),
+            VC_VALID_FROM,
+        )
+        .expect_err("duplicate validity bounds should fail");
+
+        assert_eq!(err, CredentialDecodingError::InvalidDataset);
+    }
+
+    #[test]
+    fn decode_credential_rejects_repeated_identical_validity_claims() {
+        let payload = format!(
+            r#"<{CREDENTIAL_ID}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}issuer> <{AUTHORITY_DID}> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}validFrom> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}validFrom> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}credentialSubject> <did:example:subject> .
+"#
+        );
+
+        let err = decode_nquads_credential(payload.as_bytes())
+            .expect_err("repeated validity claims should fail");
+
+        assert_eq!(err, CredentialDecodingError::InvalidDataset);
+    }
+
+    #[test]
+    fn parse_validity_bound_rejects_non_date_time_stamp_and_invalid_instants() {
+        let wrong_type = Literal::new_typed_literal(
+            "2025-01-01T00:00:00Z",
+            NamedNodeRef::new_unchecked("http://www.w3.org/2001/XMLSchema#dateTime"),
+        );
+        let invalid_instant = Literal::new_typed_literal(
+            "not-an-instant",
+            NamedNodeRef::new_unchecked("http://www.w3.org/2001/XMLSchema#dateTimeStamp"),
+        );
+
+        assert_eq!(
+            parse_validity_bound(&wrong_type),
+            Err(CredentialDecodingError::InvalidDataset)
+        );
+        assert_eq!(
+            parse_validity_bound(&invalid_instant),
+            Err(CredentialDecodingError::InvalidDataset)
+        );
     }
 
     #[test]

--- a/contracts/axone-vc/tests/integration.rs
+++ b/contracts/axone-vc/tests/integration.rs
@@ -5,7 +5,7 @@ use axone_vc::{
     AxoneVcInterface, AXONE_NAMESPACE,
 };
 use bech32::{Bech32, Hrp};
-use cosmwasm_std::Binary;
+use cosmwasm_std::{Binary, Timestamp};
 use cw_orch::contract::interface_traits::CallAs;
 use cw_orch::{anyhow, prelude::*};
 
@@ -177,6 +177,53 @@ fn issue_credential_rejects_non_host_account_sender() -> anyhow::Result<()> {
 }
 
 #[test]
+fn verify_credential_reports_activity_and_validity_interval() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    let credential_id = "urn:uuid:credential-validity";
+
+    assert_eq!(
+        AxoneVcQueryMsgFns::verify_credential(&env.app, credential_id.to_string(), None)?,
+        axone_vc::msg::VerifyCredentialResponse {
+            exists: false,
+            valid: false,
+        }
+    );
+
+    env.app.issue_credential(
+        Binary::from(credential_payload_with_validity(
+            &authority.did,
+            credential_id,
+            "1970-01-01T00:00:10Z",
+            "1970-01-01T00:00:20Z",
+        )),
+        Some(CredentialInputFormat::NQuads),
+    )?;
+
+    for (at, expected_valid) in [
+        (None, true),
+        (Some(Timestamp::from_seconds(10)), true),
+        (Some(Timestamp::from_seconds(20)), false),
+    ] {
+        let response =
+            AxoneVcQueryMsgFns::verify_credential(&env.app, credential_id.to_string(), at)?;
+        assert!(response.exists);
+        assert_eq!(response.valid, expected_valid);
+    }
+
+    env.app.revoke_credential(credential_id.to_string())?;
+    assert_eq!(
+        AxoneVcQueryMsgFns::verify_credential(&env.app, credential_id.to_string(), None)?,
+        axone_vc::msg::VerifyCredentialResponse {
+            exists: false,
+            valid: false,
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
 fn revoke_credential_accepts_issued_credential() -> anyhow::Result<()> {
     let env = TestEnv::setup()?;
     let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
@@ -318,4 +365,22 @@ fn collab_ai_zone_profile_payload_without_issuer() -> Vec<u8> {
         .collect::<Vec<_>>()
         .join("\n")
         .into_bytes()
+}
+
+fn credential_payload_with_validity(
+    authority_did: &str,
+    credential_id: &str,
+    valid_from: &str,
+    valid_until: &str,
+) -> Vec<u8> {
+    format!(
+        r#"<{credential_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{credential_id}> <https://www.w3.org/2018/credentials#issuer> <{authority_did}> .
+<{credential_id}> <https://www.w3.org/2018/credentials#issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<{credential_id}> <https://www.w3.org/2018/credentials#validFrom> "{valid_from}"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+<{credential_id}> <https://www.w3.org/2018/credentials#validUntil> "{valid_until}"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+<{credential_id}> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:subject> .
+"#
+    )
+    .into_bytes()
 }

--- a/docs/axone-vc.md
+++ b/docs/axone-vc.md
@@ -49,7 +49,7 @@ Only the app authority is allowed to call this message.
 
 The submitted payload must match the declared `format` and must describe exactly one credential that satisfies the contract invariants.
 
-The credential is accepted only if it provides: - an identifier - either no issuer or an issuer equal to the authority DID exposed by this contract - an issuance date - a subject identifier - at least one type, including `VerifiableCredential`
+The credential is accepted only if it provides: - an identifier - either no issuer or an issuer equal to the authority DID exposed by this contract - an issuance date - a subject identifier - at least one type, including `VerifiableCredential` - optional `validFrom` and `validUntil` claims, when present, encoded as `xsd:dateTimeStamp` instants with `validFrom &lt; validUntil`
 
 The submitted payload may omit the issuer. In that case, the contract treats the credential as issued by its authority DID.
 
@@ -96,6 +96,18 @@ Form:
 | ----------- | -------------------------- |
 | `authority` | _(Required.) _ **object**. |
 
+### QueryMsg::verify_credential
+
+Check whether a credential is active and, optionally, valid at a given instant.
+
+Revoked credentials are not part of the active credential set and therefore return the same result as unknown identifiers.
+
+| parameter                      | description                                                                                                                                                                      |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `verify_credential`            | _(Required.) _ **object**.                                                                                                                                                       |
+| `verify_credential.identifier` | _(Required.) _ **string**. Identifier of the credential to check.                                                                                                                |
+| `verify_credential.valid_at`   | **[Timestamp](#timestamp)\|null**. Optional instant at which to evaluate the credential validity interval.<br /><br />When omitted, every active credential is considered valid. |
+
 ## MigrateMsg
 
 Migrate message.
@@ -121,6 +133,15 @@ Response returned by `AxoneVcQueryMsg::Authority`.
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `did`    | _(Required.) _ **string**. The authority DID recognized by this contract.<br /><br />This representation uses the `did:pkh` method over the on-chain address of the host Abstract Account, rendered as a CAIP-compatible canonical Cosmos Bech32 account address.<br /><br />Form:<br /><br />`did:pkh:cosmos:&lt;chain_id&gt;:cosmos1...` |
 
+### verify_credential
+
+Response returned by `AxoneVcQueryMsg::VerifyCredential`.
+
+| property | description                                                                                                                                                       |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `exists` | _(Required.) _ **boolean**. Whether the identifier belongs to an active credential.                                                                               |
+| `valid`  | _(Required.) _ **boolean**. Whether the active credential is valid for the requested instant.<br /><br />This is equal to `exists` when no instant was requested. |
+
 ## Definitions
 
 ### Binary
@@ -139,16 +160,47 @@ Supported credential input encodings.
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | undefined | **string**: `n_quads`. UTF-8 RDF dataset serialized as N-Quads.<br /><br />N-Quads extends N-Triples to represent RDF datasets by allowing an optional fourth term that carries the graph name. See the [N-Quads specification](https://www.w3.org/TR/n-quads/). |
 
+### Timestamp
+
+A point in time in nanosecond precision.
+
+This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+
+## Examples
+
+````# use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);
+
+let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+
+
+
+### Uint64
+
+A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.
+
+# Examples
+
+Use `from` to create instances of this and `u64` to get the value out:
+
+``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+
+let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
+
+|type|
+|----|
+|**string**.|
+
 ### undefined
 
 UTF-8 RDF dataset serialized as N-Quads.
 
 N-Quads extends N-Triples to represent RDF datasets by allowing an optional fourth term that carries the graph name. See the [N-Quads specification](https://www.w3.org/TR/n-quads/).
 
-| literal     |
-| ----------- |
-| `"n_quads"` |
+|literal|
+|-------|
+|`"n_quads"`|
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`a466d08b9b644044`)_
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`26f5dd9a90e01a6a`)*
+````


### PR DESCRIPTION
Introduce credential verification with active-set and validity-interval checks.

Closes #825.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added credential validity windows using optional `validFrom` and `validUntil` timestamps.
  - Added credential verification queries that report whether a credential exists and is valid at a specified time.
  - Validity checks support inclusive start times and exclusive expiration times.

- **Bug Fixes**
  - Invalid, duplicated, incorrectly formatted, or inverted validity claims are now rejected.
  - Revoked, expired, and unknown credentials are reported as invalid.
  - Existing credentials without validity metadata remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->