### PR TITLE
✨ CredentialRaw query

### DIFF
--- a/contracts/axone-vc/src/handlers/query.rs
+++ b/contracts/axone-vc/src/handlers/query.rs
@@ -1,7 +1,7 @@
 use crate::{
     contract::{AxoneVc, AxoneVcResult},
-    msg::{AuthorityResponse, AxoneVcQueryMsg, VerifyCredentialResponse},
-    services::{authority, verify_credential},
+    msg::{AuthorityResponse, AxoneVcQueryMsg, CredentialRawResponse, VerifyCredentialResponse},
+    services::{authority, credential_raw, verify_credential},
 };
 
 use cosmwasm_std::{to_json_binary, Binary, Deps, Env};
@@ -18,6 +18,9 @@ pub fn query_handler(
             identifier,
             valid_at,
         } => to_json_binary(&query_verify_credential(deps, identifier, valid_at)?),
+        AxoneVcQueryMsg::CredentialRaw { identifier } => {
+            to_json_binary(&query_credential_raw(deps, identifier)?)
+        }
     }
     .map_err(Into::into)
 }
@@ -31,6 +34,15 @@ fn query_verify_credential(
     Ok(VerifyCredentialResponse {
         exists: result.exists,
         valid: result.valid,
+    })
+}
+
+fn query_credential_raw(
+    deps: Deps<'_>,
+    identifier: String,
+) -> AxoneVcResult<CredentialRawResponse> {
+    Ok(CredentialRawResponse {
+        credential: credential_raw(deps.storage, &identifier)?,
     })
 }
 

--- a/contracts/axone-vc/src/msg.rs
+++ b/contracts/axone-vc/src/msg.rs
@@ -119,6 +119,19 @@ pub enum AxoneVcQueryMsg {
         /// When omitted, every active credential is considered valid.
         valid_at: Option<Timestamp>,
     },
+
+    /// Return the canonical serialized representation stored for an active credential.
+    ///
+    /// The returned representation is the contract's canonical storage format. It is
+    /// not guaranteed to preserve the encoding or presentation of the issued payload.
+    ///
+    /// This query fails when the identifier is unknown or the credential has been
+    /// revoked.
+    #[returns(CredentialRawResponse)]
+    CredentialRaw {
+        /// Identifier of the credential to retrieve.
+        identifier: Uri,
+    },
 }
 
 /// Response returned by `AxoneVcQueryMsg::Authority`.
@@ -145,4 +158,14 @@ pub struct VerifyCredentialResponse {
     ///
     /// This is equal to `exists` when no instant was requested.
     pub valid: bool,
+}
+
+/// Response returned by `AxoneVcQueryMsg::CredentialRaw`.
+#[cosmwasm_schema::cw_serde]
+pub struct CredentialRawResponse {
+    /// Canonical serialized credential representation persisted by the contract.
+    ///
+    /// This binary value is base64-encoded in JSON responses and is independent
+    /// from the format and presentation of the credential submitted at issuance.
+    pub credential: Binary,
 }

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     translation::{decode_nquads_credential, CredentialDecodingError},
 };
-use cosmwasm_std::{Storage, Timestamp};
+use cosmwasm_std::{Binary, StdError, Storage, Timestamp};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq)]
@@ -111,6 +111,13 @@ pub fn verify_credential(
         exists: true,
         valid,
     })
+}
+
+pub fn credential_raw(storage: &dyn Storage, credential_id: &str) -> AxoneVcResult<Binary> {
+    let record =
+        credential(storage, credential_id)?.ok_or_else(|| StdError::not_found("credential"))?;
+
+    Ok(Binary::from(record.canonical_nquads.into_bytes()))
 }
 
 #[derive(Debug, PartialEq)]

--- a/contracts/axone-vc/src/services/mod.rs
+++ b/contracts/axone-vc/src/services/mod.rs
@@ -3,6 +3,6 @@ mod credential;
 
 pub use authority::{authority, initialize_authority};
 pub use credential::{
-    issue_credential, revoke_credential, verify_credential, IssueCredentialError,
+    credential_raw, issue_credential, revoke_credential, verify_credential, IssueCredentialError,
     RevokeCredentialError,
 };

--- a/contracts/axone-vc/tests/integration.rs
+++ b/contracts/axone-vc/tests/integration.rs
@@ -224,6 +224,74 @@ fn verify_credential_reports_activity_and_validity_interval() -> anyhow::Result<
 }
 
 #[test]
+fn credential_raw_returns_the_expected_canonical_representation() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    let credential_id = "urn:uuid:credential-raw";
+    let input = format!(
+        r#"<{credential_id}> <https://www.w3.org/2018/credentials#issuer> <{}> .
+<{credential_id}> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:subject> .
+<{credential_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{credential_id}> <https://www.w3.org/2018/credentials#issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+"#,
+        authority.did
+    );
+    let expected = format!(
+        r#"<{credential_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{credential_id}> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:subject> .
+<{credential_id}> <https://www.w3.org/2018/credentials#issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<{credential_id}> <https://www.w3.org/2018/credentials#issuer> <{}> .
+"#,
+        authority.did
+    );
+
+    assert_ne!(input, expected);
+    env.app.issue_credential(
+        Binary::from(input.into_bytes()),
+        Some(CredentialInputFormat::NQuads),
+    )?;
+
+    let response = AxoneVcQueryMsgFns::credential_raw(&env.app, credential_id.to_string())?;
+    assert_eq!(response.credential, Binary::from(expected.into_bytes()));
+
+    Ok(())
+}
+
+#[test]
+fn credential_raw_rejects_unknown_and_revoked_credentials() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let credential_id = "urn:uuid:credential-raw";
+
+    let err = AxoneVcQueryMsgFns::credential_raw(&env.app, credential_id.to_string())
+        .expect_err("unknown credential should be rejected");
+    assert!(
+        format!("{err:?}").contains("credential not found"),
+        "{err:?}"
+    );
+
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    env.app.issue_credential(
+        Binary::from(credential_payload_with_validity(
+            &authority.did,
+            credential_id,
+            "1970-01-01T00:00:10Z",
+            "1970-01-01T00:00:20Z",
+        )),
+        Some(CredentialInputFormat::NQuads),
+    )?;
+    env.app.revoke_credential(credential_id.to_string())?;
+
+    let err = AxoneVcQueryMsgFns::credential_raw(&env.app, credential_id.to_string())
+        .expect_err("revoked credential should be rejected");
+    assert!(
+        format!("{err:?}").contains("credential not found"),
+        "{err:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn revoke_credential_accepts_issued_credential() -> anyhow::Result<()> {
     let env = TestEnv::setup()?;
     let authority = AxoneVcQueryMsgFns::authority(&env.app)?;

--- a/docs/axone-vc.md
+++ b/docs/axone-vc.md
@@ -108,6 +108,19 @@ Revoked credentials are not part of the active credential set and therefore retu
 | `verify_credential.identifier` | _(Required.) _ **string**. Identifier of the credential to check.                                                                                                                |
 | `verify_credential.valid_at`   | **[Timestamp](#timestamp)\|null**. Optional instant at which to evaluate the credential validity interval.<br /><br />When omitted, every active credential is considered valid. |
 
+### QueryMsg::credential_raw
+
+Return the canonical serialized representation stored for an active credential.
+
+The returned representation is the contract's canonical storage format. It is not guaranteed to preserve the encoding or presentation of the issued payload.
+
+This query fails when the identifier is unknown or the credential has been revoked.
+
+| parameter                   | description                                                          |
+| --------------------------- | -------------------------------------------------------------------- |
+| `credential_raw`            | _(Required.) _ **object**.                                           |
+| `credential_raw.identifier` | _(Required.) _ **string**. Identifier of the credential to retrieve. |
+
 ## MigrateMsg
 
 Migrate message.
@@ -132,6 +145,14 @@ Response returned by `AxoneVcQueryMsg::Authority`.
 | property | description                                                                                                                                                                                                                                                                                                                                |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `did`    | _(Required.) _ **string**. The authority DID recognized by this contract.<br /><br />This representation uses the `did:pkh` method over the on-chain address of the host Abstract Account, rendered as a CAIP-compatible canonical Cosmos Bech32 account address.<br /><br />Form:<br /><br />`did:pkh:cosmos:&lt;chain_id&gt;:cosmos1...` |
+
+### credential_raw
+
+Response returned by `AxoneVcQueryMsg::CredentialRaw`.
+
+| property     | description                                                                                                                                                                                                                                                                   |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `credential` | _(Required.) _ **[Binary](#binary)**. Canonical serialized credential representation persisted by the contract.<br /><br />This binary value is base64-encoded in JSON responses and is independent from the format and presentation of the credential submitted at issuance. |
 
 ### verify_credential
 
@@ -202,5 +223,5 @@ N-Quads extends N-Triples to represent RDF datasets by allowing an optional four
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`26f5dd9a90e01a6a`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`162b8e70829dbb0d`)*
 ````


### PR DESCRIPTION
Introduce the `CredentialRaw` query, allowing clients to retrieve the canonical serialized representation of an active credential by identifier.

Addresses #828.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a query for retrieving an active credential’s canonical stored representation.
  * Returned credential data is provided as encoded raw bytes in canonical N-Quads format.
* **Bug Fixes**
  * Queries now clearly fail when the credential identifier is unknown or refers to a revoked credential.
* **Tests**
  * Added coverage confirming canonical formatting and validation of unavailable credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->