### PR TITLE
feat(vc)!: align credential temporal semantics

### DIFF
--- a/contracts/axone-vc/src/domain/credential.rs
+++ b/contracts/axone-vc/src/domain/credential.rs
@@ -18,9 +18,6 @@ pub enum CredentialError {
     #[error("credential issuer is invalid")]
     InvalidIssuer,
 
-    #[error("credential issuance date missing")]
-    MissingIssuanceDate,
-
     #[error("credential subject missing")]
     MissingSubject,
 
@@ -40,8 +37,6 @@ pub struct Credential {
     id: Uri,
     #[getset(get = "pub")]
     issuer: Uri,
-    #[getset(get_copy = "pub")]
-    issuance_date: Timestamp,
     #[getset(get_copy = "pub")]
     valid_from: Option<Timestamp>,
     #[getset(get_copy = "pub")]
@@ -65,9 +60,6 @@ impl TryFrom<(DecodedCredential, Authority)> for Credential {
             DecodedUri::Invalid => return Err(CredentialError::InvalidIssuer),
             DecodedUri::Uri(uri) => uri.clone(),
         };
-        let issuance_date = decoded
-            .issuance_date()
-            .ok_or(CredentialError::MissingIssuanceDate)?;
         let valid_from = *decoded.valid_from();
         let valid_until = *decoded.valid_until();
         let subject_id = match decoded.subject_id() {
@@ -97,7 +89,6 @@ impl TryFrom<(DecodedCredential, Authority)> for Credential {
         Ok(Self {
             id,
             issuer,
-            issuance_date,
             valid_from,
             valid_until,
             subject_id,
@@ -126,7 +117,6 @@ mod tests {
         DecodedCredential::new(
             Some("urn:uuid:credential-1".to_string()),
             DecodedUri::Uri(AUTHORITY_DID.to_string()),
-            Some(Timestamp::from_seconds(1_735_689_600)),
             DecodedUri::Uri("did:example:subject".to_string()),
             vec![
                 VC_TYPE.to_string(),
@@ -152,7 +142,6 @@ mod tests {
         let decoded = DecodedCredential::new(
             None,
             DecodedUri::Uri(AUTHORITY_DID.to_string()),
-            Some(Timestamp::from_seconds(1_735_689_600)),
             DecodedUri::Uri("did:example:subject".to_string()),
             vec![
                 VC_TYPE.to_string(),
@@ -171,7 +160,6 @@ mod tests {
         let decoded = DecodedCredential::new(
             Some("urn:uuid:credential-1".to_string()),
             DecodedUri::Missing,
-            Some(Timestamp::from_seconds(1_735_689_600)),
             DecodedUri::Uri("did:example:subject".to_string()),
             vec![
                 VC_TYPE.to_string(),
@@ -190,7 +178,6 @@ mod tests {
         let decoded = DecodedCredential::new(
             Some("urn:uuid:credential-1".to_string()),
             DecodedUri::Uri("did:example:issuer".to_string()),
-            Some(Timestamp::from_seconds(1_735_689_600)),
             DecodedUri::Uri("did:example:subject".to_string()),
             vec![
                 VC_TYPE.to_string(),
@@ -209,7 +196,6 @@ mod tests {
         let decoded = DecodedCredential::new(
             Some("urn:uuid:credential-1".to_string()),
             DecodedUri::Invalid,
-            Some(Timestamp::from_seconds(1_735_689_600)),
             DecodedUri::Uri("did:example:subject".to_string()),
             vec![
                 VC_TYPE.to_string(),
@@ -224,30 +210,10 @@ mod tests {
     }
 
     #[test]
-    fn try_from_requires_issuance_date() {
-        let decoded = DecodedCredential::new(
-            Some("urn:uuid:credential-1".to_string()),
-            DecodedUri::Uri(AUTHORITY_DID.to_string()),
-            None,
-            DecodedUri::Uri("did:example:subject".to_string()),
-            vec![
-                VC_TYPE.to_string(),
-                "https://example.com/types/Test".to_string(),
-            ],
-            String::new(),
-        );
-        let err = Credential::try_from((decoded, authority()))
-            .expect_err("missing issuance date should fail");
-
-        assert_eq!(err, CredentialError::MissingIssuanceDate);
-    }
-
-    #[test]
     fn try_from_requires_subject() {
         let decoded = DecodedCredential::new(
             Some("urn:uuid:credential-1".to_string()),
             DecodedUri::Uri(AUTHORITY_DID.to_string()),
-            Some(Timestamp::from_seconds(1_735_689_600)),
             DecodedUri::Missing,
             vec![
                 VC_TYPE.to_string(),
@@ -266,7 +232,6 @@ mod tests {
         let decoded = DecodedCredential::new(
             Some("urn:uuid:credential-1".to_string()),
             DecodedUri::Uri(AUTHORITY_DID.to_string()),
-            Some(Timestamp::from_seconds(1_735_689_600)),
             DecodedUri::Uri("did:example:subject".to_string()),
             vec![],
             String::new(),
@@ -282,7 +247,6 @@ mod tests {
         let decoded = DecodedCredential::new(
             Some("urn:uuid:credential-1".to_string()),
             DecodedUri::Uri(AUTHORITY_DID.to_string()),
-            Some(Timestamp::from_seconds(1_735_689_600)),
             DecodedUri::Uri("did:example:subject".to_string()),
             vec!["https://example.com/types/Test".to_string()],
             String::new(),
@@ -298,7 +262,6 @@ mod tests {
         let decoded = DecodedCredential::new(
             Some("urn:uuid:credential-1".to_string()),
             DecodedUri::Uri(AUTHORITY_DID.to_string()),
-            Some(Timestamp::from_seconds(1_735_689_600)),
             DecodedUri::Uri("did:example:subject".to_string()),
             vec![VC_TYPE.to_string()],
             String::new(),

--- a/contracts/axone-vc/src/handlers/execute.rs
+++ b/contracts/axone-vc/src/handlers/execute.rs
@@ -2,8 +2,7 @@ use crate::{
     contract::{AxoneVc, AxoneVcResult},
     msg::AxoneVcExecuteMsg,
     services::issue_credential,
-    RESPONSE_KEY_CREDENTIAL_ID, RESPONSE_KEY_IDENTIFIER, RESPONSE_KEY_ISSUED_AT,
-    RESPONSE_KEY_ISSUER, RESPONSE_KEY_REVOKED_AT, RESPONSE_KEY_SUBJECT, RESPONSE_KEY_TYPES,
+    RESPONSE_KEY_IDENTIFIER, RESPONSE_KEY_ISSUER, RESPONSE_KEY_SUBJECT, RESPONSE_KEY_TYPES,
 };
 
 use crate::services::revoke_credential;
@@ -46,23 +45,20 @@ fn execute_issue_credential(
 
     let result = issue_credential(deps.storage, credential, format)?;
 
-    Ok(module.custom_response(
-        "issue_credential",
-        vec![
-            (
-                RESPONSE_KEY_CREDENTIAL_ID.to_string(),
-                result.credential_id.clone(),
-            ),
-            (RESPONSE_KEY_IDENTIFIER.to_string(), result.credential_id),
-            (RESPONSE_KEY_ISSUER.to_string(), result.issuer),
-            (RESPONSE_KEY_SUBJECT.to_string(), result.subject),
-            (RESPONSE_KEY_TYPES.to_string(), result.types.join(",")),
-            (
-                RESPONSE_KEY_ISSUED_AT.to_string(),
-                result.issued_at.to_string(),
-            ),
-        ],
-    ))
+    let mut attributes = vec![
+        (RESPONSE_KEY_IDENTIFIER.to_string(), result.credential_id),
+        (RESPONSE_KEY_ISSUER.to_string(), result.issuer),
+        (RESPONSE_KEY_SUBJECT.to_string(), result.subject),
+        (RESPONSE_KEY_TYPES.to_string(), result.types.join(",")),
+    ];
+    if let Some(valid_from) = result.valid_from {
+        attributes.push(("valid_from".to_string(), valid_from.to_string()));
+    }
+    if let Some(valid_until) = result.valid_until {
+        attributes.push(("valid_until".to_string(), valid_until.to_string()));
+    }
+
+    Ok(module.custom_response("issue_credential", attributes))
 }
 
 fn execute_revoke_credential(
@@ -76,17 +72,13 @@ fn execute_revoke_credential(
         .admin
         .assert_admin(deps.as_ref(), &env, &info.sender)?;
 
-    let result = revoke_credential(deps.storage, &identifier, env.block.time)?;
+    let result = revoke_credential(deps.storage, &identifier)?;
 
     Ok(module.custom_response(
         "revoke_credential",
         vec![
             (RESPONSE_KEY_IDENTIFIER.to_string(), result.identifier),
             (RESPONSE_KEY_ISSUER.to_string(), result.issuer),
-            (
-                RESPONSE_KEY_REVOKED_AT.to_string(),
-                result.revoked_at.to_string(),
-            ),
         ],
     ))
 }

--- a/contracts/axone-vc/src/lib.rs
+++ b/contracts/axone-vc/src/lib.rs
@@ -17,13 +17,10 @@ pub const AXONE_NAMESPACE: &str = "axone";
 pub const AXONE_VC_NAME: &str = "axone-vc";
 pub const AXONE_VC_ID: &str = const_format::concatcp!(AXONE_NAMESPACE, ":", AXONE_VC_NAME);
 pub const RESPONSE_KEY_AUTHORITY: &str = "authority";
-pub const RESPONSE_KEY_CREDENTIAL_ID: &str = "credential_id";
 pub const RESPONSE_KEY_IDENTIFIER: &str = "identifier";
 pub const RESPONSE_KEY_ISSUER: &str = "issuer";
 pub const RESPONSE_KEY_SUBJECT: &str = "subject";
 pub const RESPONSE_KEY_TYPES: &str = "types";
-pub const RESPONSE_KEY_ISSUED_AT: &str = "issued_at";
-pub const RESPONSE_KEY_REVOKED_AT: &str = "revoked_at";
 
 // oxrdf pulls rand/getrandom transitively, but CosmWasm contracts must not depend
 // on host randomness. This custom backend keeps wasm32-unknown-unknown builds

--- a/contracts/axone-vc/src/msg.rs
+++ b/contracts/axone-vc/src/msg.rs
@@ -29,7 +29,6 @@ pub enum AxoneVcExecuteMsg {
     /// The credential is accepted only if it provides:
     /// - an identifier
     /// - either no issuer or an issuer equal to the authority DID exposed by this contract
-    /// - an issuance date
     /// - a subject identifier
     /// - at least one type, including `VerifiableCredential`
     /// - optional `validFrom` and `validUntil` claims, when present, encoded as

--- a/contracts/axone-vc/src/msg.rs
+++ b/contracts/axone-vc/src/msg.rs
@@ -62,7 +62,7 @@ pub enum AxoneVcExecuteMsg {
     /// Revocation fails if the identifier is unknown or already revoked.
     RevokeCredential {
         /// The credential identifier to revoke.
-        identifier: String,
+        identifier: Uri,
     },
 }
 

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -19,7 +19,8 @@ pub struct IssueCredentialResult {
     pub issuer: String,
     pub subject: String,
     pub types: Vec<String>,
-    pub issued_at: Timestamp,
+    pub valid_from: Option<Timestamp>,
+    pub valid_until: Option<Timestamp>,
 }
 
 #[derive(Debug, Error, PartialEq)]
@@ -52,7 +53,8 @@ pub fn issue_credential(
         issuer: credential.issuer().clone(),
         subject: credential.subject_id().clone(),
         types: credential.types().clone(),
-        issued_at: credential.issuance_date(),
+        valid_from: credential.valid_from(),
+        valid_until: credential.valid_until(),
     })
 }
 
@@ -124,7 +126,6 @@ pub fn credential_raw(storage: &dyn Storage, credential_id: &str) -> AxoneVcResu
 pub struct RevokeCredentialResult {
     pub identifier: String,
     pub issuer: String,
-    pub revoked_at: Timestamp,
 }
 
 #[derive(Debug, Error, PartialEq)]
@@ -139,7 +140,6 @@ pub enum RevokeCredentialError {
 pub fn revoke_credential(
     storage: &mut dyn Storage,
     credential_id: &str,
-    at: Timestamp,
 ) -> AxoneVcResult<RevokeCredentialResult> {
     let authority = authority(storage)?;
     if is_revoked(storage, credential_id) {
@@ -149,13 +149,12 @@ pub fn revoke_credential(
         return Err(RevokeCredentialError::UnknownCredential.into());
     }
 
-    let tombstone = CredentialTombstone::new(at);
+    let tombstone = CredentialTombstone::new();
     state::revoke_credential(storage, credential_id, &tombstone)?;
 
     Ok(RevokeCredentialResult {
         identifier: credential_id.to_string(),
         issuer: authority.did().to_string(),
-        revoked_at: at,
     })
 }
 
@@ -168,7 +167,7 @@ mod tests {
         translation::CredentialDecodingError,
     };
     use bech32::{Bech32, Hrp};
-    use cosmwasm_std::{testing::mock_dependencies, testing::mock_env, Addr};
+    use cosmwasm_std::{testing::mock_dependencies, Addr};
 
     fn credential_payload(authority_did: &str, id: &str) -> Vec<u8> {
         format!(
@@ -248,10 +247,8 @@ mod tests {
             result.types,
             vec!["https://www.w3.org/2018/credentials#VerifiableCredential"]
         );
-        assert_eq!(
-            result.issued_at,
-            cosmwasm_std::Timestamp::from_seconds(1_735_689_600)
-        );
+        assert_eq!(result.valid_from, None);
+        assert_eq!(result.valid_until, None);
 
         let record = load_credential(deps.as_ref().storage, credential_id)
             .expect("credential should be persisted");
@@ -330,7 +327,6 @@ mod tests {
     #[test]
     fn issue_credential_with_authority_rejects_revoked() {
         let mut deps = mock_dependencies();
-        let env = mock_env();
         let authority = initialized_authority(&mut deps);
         let payload = credential_payload(authority.did(), "urn:uuid:credential-1");
 
@@ -341,12 +337,8 @@ mod tests {
         )
         .expect("first submit should succeed");
 
-        revoke_credential(
-            deps.as_mut().storage,
-            "urn:uuid:credential-1",
-            env.block.time,
-        )
-        .expect("revocation should succeed");
+        revoke_credential(deps.as_mut().storage, "urn:uuid:credential-1")
+            .expect("revocation should succeed");
 
         let err = issue_credential_with_authority(
             deps.as_ref().storage,
@@ -451,7 +443,6 @@ mod tests {
     #[test]
     fn verify_credential_treats_unknown_and_revoked_credentials_as_absent() {
         let mut deps = mock_dependencies();
-        let env = mock_env();
         let authority = initialized_authority(&mut deps);
         let credential_id = "urn:uuid:credential-1";
 
@@ -470,8 +461,7 @@ mod tests {
             CredentialInputFormat::NQuads,
         )
         .expect("credential should issue");
-        revoke_credential(deps.as_mut().storage, credential_id, env.block.time)
-            .expect("credential should revoke");
+        revoke_credential(deps.as_mut().storage, credential_id).expect("credential should revoke");
 
         assert_eq!(
             verify_credential(deps.as_ref().storage, credential_id, None)
@@ -486,7 +476,6 @@ mod tests {
     #[test]
     fn revoke_credential_success() {
         let mut deps = mock_dependencies();
-        let env = mock_env();
         let authority = initialized_authority(&mut deps);
         let payload = credential_payload(authority.did(), "urn:uuid:credential-1");
 
@@ -497,18 +486,13 @@ mod tests {
         )
         .expect("submit should succeed");
 
-        let res = revoke_credential(
-            deps.as_mut().storage,
-            "urn:uuid:credential-1",
-            env.block.time,
-        );
+        let res = revoke_credential(deps.as_mut().storage, "urn:uuid:credential-1");
         assert!(res.is_ok(), "revoke should succeed");
         assert_eq!(
             res.unwrap(),
             RevokeCredentialResult {
                 identifier: "urn:uuid:credential-1".to_string(),
                 issuer: authority.did().to_string(),
-                revoked_at: env.block.time,
             }
         );
     }
@@ -516,15 +500,10 @@ mod tests {
     #[test]
     fn revoke_credential_rejects_unknown_credential() {
         let mut deps = mock_dependencies();
-        let env = mock_env();
         initialized_authority(&mut deps);
 
-        let err = revoke_credential(
-            deps.as_mut().storage,
-            "urn:uuid:credential-1",
-            env.block.time,
-        )
-        .expect_err("revocation should fail");
+        let err = revoke_credential(deps.as_mut().storage, "urn:uuid:credential-1")
+            .expect_err("revocation should fail");
 
         assert_eq!(
             err,
@@ -535,7 +514,6 @@ mod tests {
     #[test]
     fn revoke_credential_rejects_revoked_credential() {
         let mut deps = mock_dependencies();
-        let env = mock_env();
         let authority = initialized_authority(&mut deps);
         let payload = credential_payload(authority.did(), "urn:uuid:credential-1");
 
@@ -546,19 +524,11 @@ mod tests {
         )
         .expect("submit should succeed");
 
-        revoke_credential(
-            deps.as_mut().storage,
-            "urn:uuid:credential-1",
-            env.block.time,
-        )
-        .expect("first revoke should succeed");
+        revoke_credential(deps.as_mut().storage, "urn:uuid:credential-1")
+            .expect("first revoke should succeed");
 
-        let err = revoke_credential(
-            deps.as_mut().storage,
-            "urn:uuid:credential-1",
-            env.block.time,
-        )
-        .expect_err("second revocation should fail");
+        let err = revoke_credential(deps.as_mut().storage, "urn:uuid:credential-1")
+            .expect_err("second revocation should fail");
 
         assert_eq!(
             err,

--- a/contracts/axone-vc/src/state.rs
+++ b/contracts/axone-vc/src/state.rs
@@ -33,13 +33,12 @@ impl CredentialRecord {
 }
 
 #[cw_serde]
-pub struct CredentialTombstone {
-    pub revoked_at: Timestamp,
-}
+#[derive(Default)]
+pub struct CredentialTombstone {}
 
 impl CredentialTombstone {
-    pub fn new(revoked_at: Timestamp) -> Self {
-        Self { revoked_at }
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/contracts/axone-vc/src/translation/credential_rdf.rs
+++ b/contracts/axone-vc/src/translation/credential_rdf.rs
@@ -12,8 +12,6 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 const VC_ISSUER: NamedNodeRef<'static> =
     NamedNodeRef::new_unchecked("https://www.w3.org/2018/credentials#issuer");
-const VC_ISSUANCE_DATE: NamedNodeRef<'static> =
-    NamedNodeRef::new_unchecked("https://www.w3.org/2018/credentials#issuanceDate");
 const VC_VALID_FROM: NamedNodeRef<'static> =
     NamedNodeRef::new_unchecked("https://www.w3.org/2018/credentials#validFrom");
 const VC_VALID_UNTIL: NamedNodeRef<'static> =
@@ -53,8 +51,6 @@ pub struct DecodedCredential {
     #[getset(get = "pub(crate)")]
     issuer: DecodedUri,
     #[getset(get = "pub(crate)")]
-    issuance_date: Option<Timestamp>,
-    #[getset(get = "pub(crate)")]
     valid_from: Option<Timestamp>,
     #[getset(get = "pub(crate)")]
     valid_until: Option<Timestamp>,
@@ -70,7 +66,6 @@ impl DecodedCredential {
     pub(crate) fn new(
         id: Option<String>,
         issuer: DecodedUri,
-        issuance_date: Option<Timestamp>,
         subject_id: DecodedUri,
         types: Vec<String>,
         canonical_nquads: String,
@@ -78,7 +73,6 @@ impl DecodedCredential {
         Self {
             id,
             issuer,
-            issuance_date,
             valid_from: None,
             valid_until: None,
             subject_id,
@@ -107,22 +101,16 @@ pub fn decode_nquads_credential(
     let credential_subject = find_credential_subject(&dataset)?;
     let id = subject_to_identifier(&credential_subject);
     let issuer = extract_issuer(&dataset, &credential_subject)?;
-    let issuance_date = extract_issuance_date(&dataset, &credential_subject)?;
     let valid_from = extract_validity_bound(&quads, &credential_subject, VC_VALID_FROM)?;
     let valid_until = extract_validity_bound(&quads, &credential_subject, VC_VALID_UNTIL)?;
     let subject_id = extract_subject_id(&dataset, &credential_subject)?;
     let types = extract_types(&dataset, &credential_subject);
     let canonical_nquads = canonicalize_dataset(&dataset)?;
 
-    Ok(DecodedCredential::new(
-        id,
-        issuer,
-        issuance_date,
-        subject_id,
-        types,
-        canonical_nquads,
+    Ok(
+        DecodedCredential::new(id, issuer, subject_id, types, canonical_nquads)
+            .with_validity(valid_from, valid_until),
     )
-    .with_validity(valid_from, valid_until))
 }
 
 #[cfg(test)]
@@ -140,7 +128,6 @@ fn parse_nquads_quads(input: &[u8]) -> Result<Vec<Quad>, CredentialDecodingError
 fn find_credential_subject(dataset: &Dataset) -> Result<Subject, CredentialDecodingError> {
     let candidate_subjects: HashSet<Subject> = [
         VC_ISSUER,
-        VC_ISSUANCE_DATE,
         VC_VALID_FROM,
         VC_VALID_UNTIL,
         VC_CREDENTIAL_SUBJECT,
@@ -181,33 +168,6 @@ fn extract_issuer(
         [_] => Ok(DecodedUri::Invalid),
         _ => Err(CredentialDecodingError::InvalidDataset),
     }
-}
-
-fn extract_issuance_date(
-    dataset: &Dataset,
-    credential_subject: &Subject,
-) -> Result<Option<Timestamp>, CredentialDecodingError> {
-    let objects = collect_objects(dataset, credential_subject, VC_ISSUANCE_DATE);
-
-    match objects.as_slice() {
-        [] => Ok(None),
-        [Term::Literal(literal)] => parse_issuance_date(literal).map(Some),
-        _ => Err(CredentialDecodingError::InvalidDataset),
-    }
-}
-
-fn parse_issuance_date(literal: &Literal) -> Result<Timestamp, CredentialDecodingError> {
-    let datatype = literal.datatype();
-    if datatype != xsd::DATE_TIME && datatype != xsd::DATE_TIME_STAMP {
-        return Err(CredentialDecodingError::InvalidDataset);
-    }
-
-    let datetime = OffsetDateTime::parse(literal.value(), &Rfc3339)
-        .map_err(|_| CredentialDecodingError::InvalidDataset)?;
-    let nanos = datetime.unix_timestamp_nanos();
-    let nanos = u64::try_from(nanos).map_err(|_| CredentialDecodingError::InvalidDataset)?;
-
-    Ok(Timestamp::from_nanos(nanos))
 }
 
 fn extract_validity_bound(
@@ -293,10 +253,10 @@ fn map_canonicalization_error(_: rdf_canon::CanonicalizationError) -> Credential
 #[cfg(test)]
 mod tests {
     use super::{
-        decode_nquads_credential, extract_issuance_date, extract_issuer, extract_subject_id,
-        extract_validity_bound, find_credential_subject, map_canonicalization_error,
-        parse_issuance_date, parse_nquads, parse_nquads_quads, parse_validity_bound,
-        subject_to_identifier, CredentialDecodingError, DecodedUri, VC_ISSUER, VC_VALID_FROM,
+        decode_nquads_credential, extract_issuer, extract_subject_id, extract_validity_bound,
+        find_credential_subject, map_canonicalization_error, parse_nquads, parse_nquads_quads,
+        parse_validity_bound, subject_to_identifier, CredentialDecodingError, DecodedUri,
+        VC_ISSUER, VC_VALID_FROM,
     };
     use cosmwasm_std::Timestamp;
     use oxrdf::{BlankNode, Literal, NamedNodeRef, Subject};
@@ -425,8 +385,8 @@ mod tests {
     }
 
     #[test]
-    fn decode_credential_requires_valid_date() {
-        let err = decode_nquads_credential(
+    fn decode_credential_ignores_issuance_date() {
+        let decoded = decode_nquads_credential(
             format!(
                 r#"<{CREDENTIAL_ID}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
 <{CREDENTIAL_ID}> <{VC_NAMESPACE}issuer> <{AUTHORITY_DID}> .
@@ -436,9 +396,9 @@ mod tests {
             )
             .as_bytes(),
         )
-        .expect_err("invalid date should fail");
+        .expect("issuance date should be ignored");
 
-        assert_eq!(err, CredentialDecodingError::InvalidDataset);
+        assert_eq!(decoded.id().as_deref(), Some(CREDENTIAL_ID));
     }
 
     #[test]
@@ -548,45 +508,6 @@ mod tests {
     }
 
     #[test]
-    fn extract_issuance_date_rejects_non_literal_object() {
-        let dataset = parsed_dataset(
-            format!(
-                r#"<{CREDENTIAL_ID}> <{VC_NAMESPACE}issuanceDate> <did:example:not-a-literal> .
-"#
-            )
-            .as_bytes(),
-        );
-
-        let err = extract_issuance_date(
-            &dataset,
-            &Subject::NamedNode(NamedNodeRef::new_unchecked(CREDENTIAL_ID).into_owned()),
-        )
-        .expect_err("non-literal issuance date should fail");
-
-        assert_eq!(err, CredentialDecodingError::InvalidDataset);
-    }
-
-    #[test]
-    fn extract_issuance_date_rejects_multiple_values() {
-        let dataset = parsed_dataset(
-            format!(
-                r#"<{CREDENTIAL_ID}> <{VC_NAMESPACE}issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
-<{CREDENTIAL_ID}> <{VC_NAMESPACE}issuanceDate> "2025-01-02T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
-"#
-            )
-            .as_bytes(),
-        );
-
-        let err = extract_issuance_date(
-            &dataset,
-            &Subject::NamedNode(NamedNodeRef::new_unchecked(CREDENTIAL_ID).into_owned()),
-        )
-        .expect_err("multiple issuance dates should fail");
-
-        assert_eq!(err, CredentialDecodingError::InvalidDataset);
-    }
-
-    #[test]
     fn extract_subject_id_rejects_multiple_values() {
         let dataset = parsed_dataset(
             format!(
@@ -602,30 +523,6 @@ mod tests {
             &Subject::NamedNode(NamedNodeRef::new_unchecked(CREDENTIAL_ID).into_owned()),
         )
         .expect_err("multiple credential subjects should fail");
-
-        assert_eq!(err, CredentialDecodingError::InvalidDataset);
-    }
-
-    #[test]
-    fn parse_issuance_date_rejects_wrong_datatype() {
-        let literal = Literal::new_typed_literal(
-            "2025-01-01T00:00:00Z",
-            NamedNodeRef::new_unchecked("http://www.w3.org/2001/XMLSchema#string"),
-        );
-
-        let err = parse_issuance_date(&literal).expect_err("wrong datatype should fail");
-
-        assert_eq!(err, CredentialDecodingError::InvalidDataset);
-    }
-
-    #[test]
-    fn parse_issuance_date_rejects_pre_unix_epoch_values() {
-        let literal = Literal::new_typed_literal(
-            "1960-01-01T00:00:00Z",
-            NamedNodeRef::new_unchecked("http://www.w3.org/2001/XMLSchema#dateTime"),
-        );
-
-        let err = parse_issuance_date(&literal).expect_err("negative timestamps should fail");
 
         assert_eq!(err, CredentialDecodingError::InvalidDataset);
     }

--- a/contracts/axone-vc/tests/integration.rs
+++ b/contracts/axone-vc/tests/integration.rs
@@ -116,12 +116,15 @@ fn issue_credential_emits_event() -> anyhow::Result<()> {
             .expect("Missing types attribute"),
         "https://w3id.org/axone/ontology/v4/schema/core/assertion/AssertionCredential,https://www.w3.org/2018/credentials#VerifiableCredential"
     );
-    assert_eq!(
-        response
-            .event_attr_value(ABSTRACT_EVENT_TYPE, "issued_at")
-            .expect("Missing issued_at attribute"),
-        "1781128800.000000000"
-    );
+    assert!(response
+        .event_attr_value(ABSTRACT_EVENT_TYPE, "issued_at")
+        .is_err());
+    assert!(response
+        .event_attr_value(ABSTRACT_EVENT_TYPE, "valid_from")
+        .is_err());
+    assert!(response
+        .event_attr_value(ABSTRACT_EVENT_TYPE, "valid_until")
+        .is_err());
 
     Ok(())
 }
@@ -190,7 +193,7 @@ fn verify_credential_reports_activity_and_validity_interval() -> anyhow::Result<
         }
     );
 
-    env.app.issue_credential(
+    let issue_response = env.app.issue_credential(
         Binary::from(credential_payload_with_validity(
             &authority.did,
             credential_id,
@@ -199,6 +202,18 @@ fn verify_credential_reports_activity_and_validity_interval() -> anyhow::Result<
         )),
         Some(CredentialInputFormat::NQuads),
     )?;
+    assert_eq!(
+        issue_response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "valid_from")
+            .expect("Missing valid_from attribute"),
+        "10.000000000"
+    );
+    assert_eq!(
+        issue_response
+            .event_attr_value(ABSTRACT_EVENT_TYPE, "valid_until")
+            .expect("Missing valid_until attribute"),
+        "20.000000000"
+    );
 
     for (at, expected_valid) in [
         (None, true),
@@ -337,8 +352,7 @@ fn revoke_credential_emits_event() -> anyhow::Result<()> {
     );
     assert!(response
         .event_attr_value(ABSTRACT_EVENT_TYPE, "revoked_at")
-        .expect("Missing revoked_at attribute")
-        .contains('.'));
+        .is_err());
 
     Ok(())
 }
@@ -444,7 +458,6 @@ fn credential_payload_with_validity(
     format!(
         r#"<{credential_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
 <{credential_id}> <https://www.w3.org/2018/credentials#issuer> <{authority_did}> .
-<{credential_id}> <https://www.w3.org/2018/credentials#issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
 <{credential_id}> <https://www.w3.org/2018/credentials#validFrom> "{valid_from}"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
 <{credential_id}> <https://www.w3.org/2018/credentials#validUntil> "{valid_until}"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
 <{credential_id}> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:subject> .

--- a/docs/axone-vc.md
+++ b/docs/axone-vc.md
@@ -49,7 +49,7 @@ Only the app authority is allowed to call this message.
 
 The submitted payload must match the declared `format` and must describe exactly one credential that satisfies the contract invariants.
 
-The credential is accepted only if it provides: - an identifier - either no issuer or an issuer equal to the authority DID exposed by this contract - an issuance date - a subject identifier - at least one type, including `VerifiableCredential` - optional `validFrom` and `validUntil` claims, when present, encoded as `xsd:dateTimeStamp` instants with `validFrom &lt; validUntil`
+The credential is accepted only if it provides: - an identifier - either no issuer or an issuer equal to the authority DID exposed by this contract - a subject identifier - at least one type, including `VerifiableCredential` - optional `validFrom` and `validUntil` claims, when present, encoded as `xsd:dateTimeStamp` instants with `validFrom &lt; validUntil`
 
 The submitted payload may omit the issuer. In that case, the contract treats the credential as issued by its authority DID.
 
@@ -223,5 +223,5 @@ N-Quads extends N-Triples to represent RDF datasets by allowing an optional four
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`162b8e70829dbb0d`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`dd24f8a7a1cbe498`)*
 ````


### PR DESCRIPTION
Remove the ambiguous `issued_at` concept from the `axone-vc` contract API. The contract now exposes only the optional validity interval declared by the credential (`validFrom`,  `validUntil`).

The transaction and block already provide the time at which `IssueCredential` or `RevokeCredentiam` was executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credential issuance no longer requires an issuance date.
  * Issuance responses now report optional validity start and end dates.
  * Revocation records no longer include a revocation timestamp.
  * Revocation identifiers now use URI formatting.

* **Bug Fixes**
  * Credentials with invalid issuance-date values are no longer rejected when validity intervals remain valid.
  * Event attributes now accurately reflect the updated issuance and revocation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->