### PR TITLE
feat(vc): adds the credential query

### DIFF
--- a/contracts/axone-vc/src/domain/authority.rs
+++ b/contracts/axone-vc/src/domain/authority.rs
@@ -25,11 +25,6 @@ impl Authority {
     pub fn did(&self) -> &str {
         &self.0
     }
-
-    #[cfg(test)]
-    pub(crate) fn from_state(did: String) -> Self {
-        Self(did)
-    }
 }
 
 fn canonical_cosmos_account_address(account_addr: &Addr) -> StdResult<String> {

--- a/contracts/axone-vc/src/domain/credential.rs
+++ b/contracts/axone-vc/src/domain/credential.rs
@@ -1,7 +1,4 @@
-use crate::{
-    domain::Authority,
-    translation::{DecodedCredential, DecodedUri},
-};
+use crate::translation::{DecodedCredential, DecodedUri};
 use cosmwasm_std::Timestamp;
 use getset::{CopyGetters, Getters};
 use thiserror::Error;
@@ -45,34 +42,6 @@ pub struct Credential {
     subject_id: Uri,
     #[getset(get = "pub")]
     types: Vec<String>,
-}
-
-impl TryFrom<(DecodedCredential, Authority)> for Credential {
-    type Error = CredentialError;
-
-    fn try_from((decoded, authority): (DecodedCredential, Authority)) -> Result<Self, Self::Error> {
-        let id = decoded
-            .id()
-            .clone()
-            .ok_or(CredentialError::MissingIdentifier)?;
-        let issuer = match decoded.issuer() {
-            DecodedUri::Missing => authority.did().to_string(),
-            DecodedUri::Invalid => return Err(CredentialError::InvalidIssuer),
-            DecodedUri::Uri(uri) => uri.clone(),
-        };
-        if issuer != authority.did() {
-            return Err(CredentialError::InvalidIssuer);
-        }
-
-        Self::try_new(
-            id,
-            issuer,
-            *decoded.valid_from(),
-            *decoded.valid_until(),
-            decoded.subject_id(),
-            decoded.types().clone(),
-        )
-    }
 }
 
 impl TryFrom<DecodedCredential> for Credential {
@@ -144,17 +113,13 @@ impl Credential {
 mod tests {
     use super::Credential;
     use crate::{
-        domain::{Authority, CredentialError},
+        domain::CredentialError,
         translation::{DecodedCredential, DecodedUri},
     };
     use cosmwasm_std::Timestamp;
 
     const AUTHORITY_DID: &str = "did:pkh:cosmos:axone-localnet-1:cosmos1authority";
     const VC_TYPE: &str = "https://www.w3.org/2018/credentials#VerifiableCredential";
-
-    fn authority() -> Authority {
-        Authority::from_state(AUTHORITY_DID.to_string())
-    }
 
     fn decoded_credential() -> DecodedCredential {
         DecodedCredential::new(
@@ -171,17 +136,6 @@ mod tests {
 
     #[test]
     fn try_from_accepts_valid_credential() {
-        let credential = Credential::try_from((decoded_credential(), authority()))
-            .expect("credential should be valid");
-
-        assert_eq!(credential.id(), "urn:uuid:credential-1");
-        assert_eq!(credential.issuer(), AUTHORITY_DID);
-        assert_eq!(credential.subject_id(), "did:example:subject");
-        assert_eq!(credential.types().len(), 2);
-    }
-
-    #[test]
-    fn try_from_decoded_credential_accepts_stored_credential() {
         let credential =
             Credential::try_from(decoded_credential()).expect("credential should be valid");
 
@@ -218,32 +172,13 @@ mod tests {
             ],
             String::new(),
         );
-        let err = Credential::try_from((decoded, authority()))
-            .expect_err("missing identifier should fail");
+        let err = Credential::try_from(decoded).expect_err("missing identifier should fail");
 
         assert_eq!(err, CredentialError::MissingIdentifier);
     }
 
     #[test]
-    fn try_from_infers_missing_issuer_from_authority() {
-        let decoded = DecodedCredential::new(
-            Some("urn:uuid:credential-1".to_string()),
-            DecodedUri::Missing,
-            DecodedUri::Uri("did:example:subject".to_string()),
-            vec![
-                VC_TYPE.to_string(),
-                "https://example.com/types/Test".to_string(),
-            ],
-            String::new(),
-        );
-        let credential = Credential::try_from((decoded, authority()))
-            .expect("missing issuer should be inferred from authority");
-
-        assert_eq!(credential.issuer(), AUTHORITY_DID);
-    }
-
-    #[test]
-    fn try_from_rejects_invalid_issuer() {
+    fn try_from_accepts_any_valid_issuer() {
         let decoded = DecodedCredential::new(
             Some("urn:uuid:credential-1".to_string()),
             DecodedUri::Uri("did:example:issuer".to_string()),
@@ -254,10 +189,9 @@ mod tests {
             ],
             String::new(),
         );
-        let err =
-            Credential::try_from((decoded, authority())).expect_err("issuer mismatch should fail");
+        let credential = Credential::try_from(decoded).expect("credential should be valid");
 
-        assert_eq!(err, CredentialError::InvalidIssuer);
+        assert_eq!(credential.issuer(), "did:example:issuer");
     }
 
     #[test]
@@ -272,8 +206,7 @@ mod tests {
             ],
             String::new(),
         );
-        let err =
-            Credential::try_from((decoded, authority())).expect_err("invalid issuer should fail");
+        let err = Credential::try_from(decoded).expect_err("invalid issuer should fail");
 
         assert_eq!(err, CredentialError::InvalidIssuer);
     }
@@ -290,8 +223,7 @@ mod tests {
             ],
             String::new(),
         );
-        let err =
-            Credential::try_from((decoded, authority())).expect_err("missing subject should fail");
+        let err = Credential::try_from(decoded).expect_err("missing subject should fail");
 
         assert_eq!(err, CredentialError::MissingSubject);
     }
@@ -305,8 +237,7 @@ mod tests {
             vec![],
             String::new(),
         );
-        let err =
-            Credential::try_from((decoded, authority())).expect_err("missing types should fail");
+        let err = Credential::try_from(decoded).expect_err("missing types should fail");
 
         assert_eq!(err, CredentialError::MissingType);
     }
@@ -320,8 +251,7 @@ mod tests {
             vec!["https://example.com/types/Test".to_string()],
             String::new(),
         );
-        let err =
-            Credential::try_from((decoded, authority())).expect_err("missing vc type should fail");
+        let err = Credential::try_from(decoded).expect_err("missing vc type should fail");
 
         assert_eq!(err, CredentialError::NotVerifiableCredential);
     }
@@ -340,8 +270,8 @@ mod tests {
             Some(Timestamp::from_seconds(10)),
         );
 
-        let err = Credential::try_from((decoded, authority()))
-            .expect_err("inverted validity interval should fail");
+        let err =
+            Credential::try_from(decoded).expect_err("inverted validity interval should fail");
 
         assert_eq!(err, CredentialError::InvalidValidityInterval);
     }

--- a/contracts/axone-vc/src/domain/credential.rs
+++ b/contracts/axone-vc/src/domain/credential.rs
@@ -60,19 +60,62 @@ impl TryFrom<(DecodedCredential, Authority)> for Credential {
             DecodedUri::Invalid => return Err(CredentialError::InvalidIssuer),
             DecodedUri::Uri(uri) => uri.clone(),
         };
-        let valid_from = *decoded.valid_from();
-        let valid_until = *decoded.valid_until();
-        let subject_id = match decoded.subject_id() {
+        if issuer != authority.did() {
+            return Err(CredentialError::InvalidIssuer);
+        }
+
+        Self::try_new(
+            id,
+            issuer,
+            *decoded.valid_from(),
+            *decoded.valid_until(),
+            decoded.subject_id(),
+            decoded.types().clone(),
+        )
+    }
+}
+
+impl TryFrom<DecodedCredential> for Credential {
+    type Error = CredentialError;
+
+    fn try_from(decoded: DecodedCredential) -> Result<Self, Self::Error> {
+        let id = decoded
+            .id()
+            .clone()
+            .ok_or(CredentialError::MissingIdentifier)?;
+        let issuer = match decoded.issuer() {
+            DecodedUri::Uri(uri) => uri.clone(),
+            DecodedUri::Missing | DecodedUri::Invalid => {
+                return Err(CredentialError::InvalidIssuer);
+            }
+        };
+
+        Self::try_new(
+            id,
+            issuer,
+            *decoded.valid_from(),
+            *decoded.valid_until(),
+            decoded.subject_id(),
+            decoded.types().clone(),
+        )
+    }
+}
+
+impl Credential {
+    fn try_new(
+        id: Uri,
+        issuer: Uri,
+        valid_from: Option<Timestamp>,
+        valid_until: Option<Timestamp>,
+        subject_id: &DecodedUri,
+        types: Vec<String>,
+    ) -> Result<Self, CredentialError> {
+        let subject_id = match subject_id {
             DecodedUri::Uri(uri) => uri.clone(),
             DecodedUri::Missing | DecodedUri::Invalid => {
                 return Err(CredentialError::MissingSubject);
             }
         };
-        let types = decoded.types().clone();
-
-        if issuer != authority.did() {
-            return Err(CredentialError::InvalidIssuer);
-        }
 
         if types.is_empty() {
             return Err(CredentialError::MissingType);
@@ -135,6 +178,32 @@ mod tests {
         assert_eq!(credential.issuer(), AUTHORITY_DID);
         assert_eq!(credential.subject_id(), "did:example:subject");
         assert_eq!(credential.types().len(), 2);
+    }
+
+    #[test]
+    fn try_from_decoded_credential_accepts_stored_credential() {
+        let credential =
+            Credential::try_from(decoded_credential()).expect("credential should be valid");
+
+        assert_eq!(credential.id(), "urn:uuid:credential-1");
+        assert_eq!(credential.issuer(), AUTHORITY_DID);
+        assert_eq!(credential.subject_id(), "did:example:subject");
+        assert_eq!(credential.types().len(), 2);
+    }
+
+    #[test]
+    fn try_from_decoded_credential_requires_explicit_issuer() {
+        let decoded = DecodedCredential::new(
+            Some("urn:uuid:credential-1".to_string()),
+            DecodedUri::Missing,
+            DecodedUri::Uri("did:example:subject".to_string()),
+            vec![VC_TYPE.to_string()],
+            String::new(),
+        );
+
+        let err = Credential::try_from(decoded).expect_err("missing issuer should fail");
+
+        assert_eq!(err, CredentialError::InvalidIssuer);
     }
 
     #[test]

--- a/contracts/axone-vc/src/error.rs
+++ b/contracts/axone-vc/src/error.rs
@@ -1,4 +1,8 @@
-use crate::services::{IssueCredentialError, RevokeCredentialError};
+use crate::{
+    domain::CredentialError,
+    services::{IssueCredentialError, RevokeCredentialError},
+    translation::CredentialDecodingError,
+};
 use abstract_app::sdk::AbstractSdkError;
 use abstract_app::std::AbstractError;
 use abstract_app::AppError;
@@ -28,4 +32,10 @@ pub enum AxoneVcError {
 
     #[error(transparent)]
     RevokeCredential(#[from] RevokeCredentialError),
+
+    #[error(transparent)]
+    Credential(#[from] CredentialError),
+
+    #[error(transparent)]
+    CredentialDecode(#[from] CredentialDecodingError),
 }

--- a/contracts/axone-vc/src/handlers/query.rs
+++ b/contracts/axone-vc/src/handlers/query.rs
@@ -2,12 +2,14 @@ use crate::{
     contract::{AxoneVc, AxoneVcResult},
     msg::{
         AuthorityResponse, AxoneVcQueryMsg, CredentialRawResponse, CredentialResponse,
-        VerifyCredentialResponse,
+        Quad as QuadResponse, VerifyCredentialResponse,
     },
     services::{authority, credential, credential_raw, verify_credential},
+    translation::DecodedQuad,
 };
 
 use cosmwasm_std::{to_json_binary, Binary, Deps, Env};
+use oxrdf::GraphName;
 
 pub fn query_handler(
     deps: Deps<'_>,
@@ -61,7 +63,7 @@ fn query_credential(deps: Deps<'_>, identifier: String) -> AxoneVcResult<Credent
         subject: result.parsed.subject_id().clone(),
         valid_from: result.parsed.valid_from(),
         valid_until: result.parsed.valid_until(),
-        quads: result.canonical,
+        quads: result.quads.into_iter().map(QuadResponse::from).collect(),
     })
 }
 
@@ -70,4 +72,18 @@ fn query_authority(deps: Deps<'_>) -> AxoneVcResult<AuthorityResponse> {
     Ok(AuthorityResponse {
         did: authority.did().to_string(),
     })
+}
+
+impl From<DecodedQuad> for QuadResponse {
+    fn from(quad: DecodedQuad) -> Self {
+        Self {
+            subject: quad.subject.to_string(),
+            predicate: quad.predicate.to_string(),
+            object: quad.object.to_string(),
+            graph_name: match quad.graph_name {
+                GraphName::DefaultGraph => None,
+                graph_name => Some(graph_name.to_string()),
+            },
+        }
+    }
 }

--- a/contracts/axone-vc/src/handlers/query.rs
+++ b/contracts/axone-vc/src/handlers/query.rs
@@ -1,7 +1,10 @@
 use crate::{
     contract::{AxoneVc, AxoneVcResult},
-    msg::{AuthorityResponse, AxoneVcQueryMsg, CredentialRawResponse, VerifyCredentialResponse},
-    services::{authority, credential_raw, verify_credential},
+    msg::{
+        AuthorityResponse, AxoneVcQueryMsg, CredentialRawResponse, CredentialResponse,
+        VerifyCredentialResponse,
+    },
+    services::{authority, credential, credential_raw, verify_credential},
 };
 
 use cosmwasm_std::{to_json_binary, Binary, Deps, Env};
@@ -20,6 +23,9 @@ pub fn query_handler(
         } => to_json_binary(&query_verify_credential(deps, identifier, valid_at)?),
         AxoneVcQueryMsg::CredentialRaw { identifier } => {
             to_json_binary(&query_credential_raw(deps, identifier)?)
+        }
+        AxoneVcQueryMsg::Credential { identifier } => {
+            to_json_binary(&query_credential(deps, identifier)?)
         }
     }
     .map_err(Into::into)
@@ -43,6 +49,19 @@ fn query_credential_raw(
 ) -> AxoneVcResult<CredentialRawResponse> {
     Ok(CredentialRawResponse {
         credential: credential_raw(deps.storage, &identifier)?,
+    })
+}
+
+fn query_credential(deps: Deps<'_>, identifier: String) -> AxoneVcResult<CredentialResponse> {
+    let result = credential(deps.storage, &identifier)?;
+    Ok(CredentialResponse {
+        identifier: result.parsed.id().clone(),
+        types: result.parsed.types().clone(),
+        issuer: result.parsed.issuer().clone(),
+        subject: result.parsed.subject_id().clone(),
+        valid_from: result.parsed.valid_from(),
+        valid_until: result.parsed.valid_until(),
+        quads: result.canonical,
     })
 }
 

--- a/contracts/axone-vc/src/msg.rs
+++ b/contracts/axone-vc/src/msg.rs
@@ -34,8 +34,10 @@ pub enum AxoneVcExecuteMsg {
     /// - optional `validFrom` and `validUntil` claims, when present, encoded as
     ///   `xsd:dateTimeStamp` instants with `validFrom < validUntil`
     ///
-    /// The submitted payload may omit the issuer. In that case, the contract
-    /// treats the credential as issued by its authority DID.
+    /// When the submitted payload omits the issuer, the contract adds its authority
+    /// DID as the credential issuer.
+    ///
+    /// The registered credential therefore always contains the effective issuer.
     ///
     /// Issuance fails if the payload format is not supported, if the credential
     /// representation cannot be interpreted according to that format, or if a

--- a/contracts/axone-vc/src/msg.rs
+++ b/contracts/axone-vc/src/msg.rs
@@ -131,6 +131,20 @@ pub enum AxoneVcQueryMsg {
         /// Identifier of the credential to retrieve.
         identifier: Uri,
     },
+
+    /// Return an active issued credential with its canonical RDF dataset.
+    ///
+    /// The returned metadata is reconstructed from the credential RDF dataset
+    /// accepted at issuance. The `quads` field contains the canonical N-Quads
+    /// string representation stored by this authority.
+    ///
+    /// This query fails when the identifier is unknown or the credential has been
+    /// revoked.
+    #[returns(CredentialResponse)]
+    Credential {
+        /// Identifier of the credential to retrieve.
+        identifier: Uri,
+    },
 }
 
 /// Response returned by `AxoneVcQueryMsg::Authority`.
@@ -167,4 +181,23 @@ pub struct CredentialRawResponse {
     /// This binary value is base64-encoded in JSON responses and is independent
     /// from the format and presentation of the credential submitted at issuance.
     pub credential: Binary,
+}
+
+/// Response returned by `AxoneVcQueryMsg::Credential`.
+#[cosmwasm_schema::cw_serde]
+pub struct CredentialResponse {
+    /// Credential identifier extracted from the VC `id`.
+    pub identifier: Uri,
+    /// Credential type URIs extracted from the VC `type` values.
+    pub types: Vec<Uri>,
+    /// Authority DID recorded as the credential issuer.
+    pub issuer: Uri,
+    /// Credential subject identifier.
+    pub subject: Uri,
+    /// Optional lower bound of the credential validity interval.
+    pub valid_from: Option<Timestamp>,
+    /// Optional exclusive upper bound of the credential validity interval.
+    pub valid_until: Option<Timestamp>,
+    /// Canonical N-Quads string representation of the credential RDF dataset.
+    pub quads: String,
 }

--- a/contracts/axone-vc/src/msg.rs
+++ b/contracts/axone-vc/src/msg.rs
@@ -132,11 +132,11 @@ pub enum AxoneVcQueryMsg {
         identifier: Uri,
     },
 
-    /// Return an active issued credential with its canonical RDF dataset.
+    /// Return an active issued credential with its RDF dataset.
     ///
     /// The returned metadata is reconstructed from the credential RDF dataset
-    /// accepted at issuance. The `quads` field contains the canonical N-Quads
-    /// string representation stored by this authority.
+    /// accepted at issuance. The `quads` field contains the canonical dataset
+    /// as structured RDF quads.
     ///
     /// This query fails when the identifier is unknown or the credential has been
     /// revoked.
@@ -198,6 +198,19 @@ pub struct CredentialResponse {
     pub valid_from: Option<Timestamp>,
     /// Optional exclusive upper bound of the credential validity interval.
     pub valid_until: Option<Timestamp>,
-    /// Canonical N-Quads string representation of the credential RDF dataset.
-    pub quads: String,
+    /// Canonical credential RDF dataset represented as structured quads.
+    pub quads: Vec<Quad>,
+}
+
+/// RDF quad returned by `AxoneVcQueryMsg::Credential`.
+#[cosmwasm_schema::cw_serde]
+pub struct Quad {
+    /// RDF subject term serialized with N-Quads term syntax.
+    pub subject: String,
+    /// RDF predicate IRI serialized with N-Quads term syntax.
+    pub predicate: String,
+    /// RDF object term serialized with N-Quads term syntax.
+    pub object: String,
+    /// RDF graph name serialized with N-Quads term syntax, or `None` for the default graph.
+    pub graph_name: Option<String>,
 }

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     translation::{
         decode_canonical_nquads_credential, decode_nquads_credential_for_issuer,
-        CredentialDecodingError,
+        CredentialDecodingError, DecodedQuad,
     },
 };
 use cosmwasm_std::{Binary, StdError, Storage, Timestamp};
@@ -130,7 +130,7 @@ pub fn credential_raw(storage: &dyn Storage, credential_id: &str) -> AxoneVcResu
 #[derive(Debug, PartialEq)]
 pub struct CredentialResult {
     pub parsed: Credential,
-    pub canonical: String,
+    pub quads: Vec<DecodedQuad>,
 }
 
 pub fn credential(storage: &dyn Storage, credential_id: &str) -> AxoneVcResult<CredentialResult> {
@@ -138,10 +138,10 @@ pub fn credential(storage: &dyn Storage, credential_id: &str) -> AxoneVcResult<C
         .ok_or_else(|| StdError::not_found("credential"))?;
     let canonical = record.canonical_nquads;
     let decoded = decode_canonical_nquads_credential(&canonical)?;
-    let canonical = decoded.canonical_nquads().clone();
+    let quads = decoded.quads().clone();
     let parsed = Credential::try_from(decoded)?;
 
-    Ok(CredentialResult { parsed, canonical })
+    Ok(CredentialResult { parsed, quads })
 }
 
 #[derive(Debug, PartialEq)]
@@ -426,7 +426,7 @@ mod tests {
     }
 
     #[test]
-    fn credential_returns_parsed_credential_and_canonical_representation() {
+    fn credential_returns_parsed_credential_and_decoded_quads() {
         let mut deps = mock_dependencies();
         let authority = initialized_authority(&mut deps);
         let credential_id = "urn:uuid:credential-query";
@@ -457,10 +457,16 @@ mod tests {
         );
         assert_eq!(result.parsed.valid_from(), Some(valid_from));
         assert_eq!(result.parsed.valid_until(), Some(valid_until));
-        assert!(result.canonical.contains(credential_id));
-        assert!(result.canonical.contains(authority.did()));
-        assert!(result.canonical.contains("validFrom"));
-        assert!(result.canonical.contains("validUntil"));
+        let quads = result
+            .quads
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(quads.contains(credential_id));
+        assert!(quads.contains(authority.did()));
+        assert!(quads.contains("validFrom"));
+        assert!(quads.contains("validUntil"));
     }
 
     #[test]

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -9,7 +9,8 @@ use crate::{
         CredentialRecord, CredentialTombstone,
     },
     translation::{
-        decode_canonical_nquads_credential, decode_nquads_credential, CredentialDecodingError,
+        decode_canonical_nquads_credential, decode_nquads_credential_for_issuer,
+        CredentialDecodingError,
     },
 };
 use cosmwasm_std::{Binary, StdError, Storage, Timestamp};
@@ -67,12 +68,14 @@ fn issue_credential_with_authority(
     format: CredentialInputFormat,
 ) -> Result<(Credential, CredentialRecord), IssueCredentialError> {
     let decoded = match format {
-        CredentialInputFormat::NQuads => decode_nquads_credential(input)?,
+        CredentialInputFormat::NQuads => {
+            decode_nquads_credential_for_issuer(input, authority.did())?
+        }
     };
     let canonical_nquads = decoded.canonical_nquads().clone();
     let valid_from = *decoded.valid_from();
     let valid_until = *decoded.valid_until();
-    let credential = Credential::try_from((decoded, authority))?;
+    let credential = Credential::try_from(decoded)?;
 
     if has_credential(storage, credential.id()) {
         return Err(IssueCredentialError::CredentialAlreadyExists);
@@ -307,7 +310,7 @@ mod tests {
     fn issue_credential_accepts_missing_issuer() {
         let mut deps = mock_dependencies();
         let credential_id = "urn:uuid:credential-2";
-        initialized_authority(&mut deps);
+        let authority = initialized_authority(&mut deps);
 
         let result = issue_credential(
             deps.as_mut().storage,
@@ -317,6 +320,14 @@ mod tests {
         .expect("missing issuer should be inferred from authority");
 
         assert_eq!(result.credential_id, credential_id);
+        assert_eq!(result.issuer, authority.did());
+
+        let record = load_credential(deps.as_ref().storage, credential_id)
+            .expect("credential should be persisted");
+        assert!(record.canonical_nquads.contains(&format!(
+            "<{credential_id}> <https://www.w3.org/2018/credentials#issuer> <{}> .",
+            authority.did()
+        )));
     }
 
     #[test]

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -5,10 +5,12 @@ use crate::{
     services::authority,
     state,
     state::{
-        credential, has_credential, is_revoked, record_credential, CredentialRecord,
-        CredentialTombstone,
+        credential as stored_credential, has_credential, is_revoked, record_credential,
+        CredentialRecord, CredentialTombstone,
     },
-    translation::{decode_nquads_credential, CredentialDecodingError},
+    translation::{
+        decode_canonical_nquads_credential, decode_nquads_credential, CredentialDecodingError,
+    },
 };
 use cosmwasm_std::{Binary, StdError, Storage, Timestamp};
 use thiserror::Error;
@@ -97,7 +99,7 @@ pub fn verify_credential(
     credential_id: &str,
     valid_at: Option<Timestamp>,
 ) -> AxoneVcResult<VerifyCredentialResult> {
-    let Some(record) = credential(storage, credential_id)? else {
+    let Some(record) = stored_credential(storage, credential_id)? else {
         return Ok(VerifyCredentialResult {
             exists: false,
             valid: false,
@@ -116,10 +118,27 @@ pub fn verify_credential(
 }
 
 pub fn credential_raw(storage: &dyn Storage, credential_id: &str) -> AxoneVcResult<Binary> {
-    let record =
-        credential(storage, credential_id)?.ok_or_else(|| StdError::not_found("credential"))?;
+    let record = stored_credential(storage, credential_id)?
+        .ok_or_else(|| StdError::not_found("credential"))?;
 
     Ok(Binary::from(record.canonical_nquads.into_bytes()))
+}
+
+#[derive(Debug, PartialEq)]
+pub struct CredentialResult {
+    pub parsed: Credential,
+    pub canonical: String,
+}
+
+pub fn credential(storage: &dyn Storage, credential_id: &str) -> AxoneVcResult<CredentialResult> {
+    let record = stored_credential(storage, credential_id)?
+        .ok_or_else(|| StdError::not_found("credential"))?;
+    let canonical = record.canonical_nquads;
+    let decoded = decode_canonical_nquads_credential(&canonical)?;
+    let canonical = decoded.canonical_nquads().clone();
+    let parsed = Credential::try_from(decoded)?;
+
+    Ok(CredentialResult { parsed, canonical })
 }
 
 #[derive(Debug, PartialEq)]
@@ -393,6 +412,67 @@ mod tests {
                 }
             );
         }
+    }
+
+    #[test]
+    fn credential_returns_parsed_credential_and_canonical_representation() {
+        let mut deps = mock_dependencies();
+        let authority = initialized_authority(&mut deps);
+        let credential_id = "urn:uuid:credential-query";
+        let valid_from = Timestamp::from_seconds(10);
+        let valid_until = Timestamp::from_seconds(20);
+
+        issue_credential(
+            deps.as_mut().storage,
+            &credential_payload_with_validity(
+                authority.did(),
+                credential_id,
+                "1970-01-01T00:00:10Z",
+                "1970-01-01T00:00:20Z",
+            ),
+            CredentialInputFormat::NQuads,
+        )
+        .expect("credential should issue");
+
+        let result =
+            credential(deps.as_ref().storage, credential_id).expect("credential should load");
+
+        assert_eq!(result.parsed.id(), credential_id);
+        assert_eq!(result.parsed.issuer(), authority.did());
+        assert_eq!(result.parsed.subject_id(), "did:example:subject");
+        assert_eq!(
+            result.parsed.types(),
+            &vec!["https://www.w3.org/2018/credentials#VerifiableCredential".to_string()]
+        );
+        assert_eq!(result.parsed.valid_from(), Some(valid_from));
+        assert_eq!(result.parsed.valid_until(), Some(valid_until));
+        assert!(result.canonical.contains(credential_id));
+        assert!(result.canonical.contains(authority.did()));
+        assert!(result.canonical.contains("validFrom"));
+        assert!(result.canonical.contains("validUntil"));
+    }
+
+    #[test]
+    fn credential_rejects_unknown_and_revoked_credentials() {
+        let mut deps = mock_dependencies();
+        let authority = initialized_authority(&mut deps);
+        let credential_id = "urn:uuid:credential-query";
+
+        let err = credential(deps.as_ref().storage, credential_id)
+            .expect_err("unknown credential should fail");
+        assert!(err.to_string().contains("credential not found"));
+
+        issue_credential(
+            deps.as_mut().storage,
+            &credential_payload(authority.did(), credential_id),
+            CredentialInputFormat::NQuads,
+        )
+        .expect("credential should issue");
+        revoke_credential(deps.as_mut().storage, credential_id).expect("credential should revoke");
+
+        let err = credential(deps.as_ref().storage, credential_id)
+            .expect_err("revoked credential should fail");
+        assert!(err.to_string().contains("credential not found"));
     }
 
     #[test]

--- a/contracts/axone-vc/src/services/mod.rs
+++ b/contracts/axone-vc/src/services/mod.rs
@@ -3,6 +3,6 @@ mod credential;
 
 pub use authority::{authority, initialize_authority};
 pub use credential::{
-    credential_raw, issue_credential, revoke_credential, verify_credential, IssueCredentialError,
-    RevokeCredentialError,
+    credential, credential_raw, issue_credential, revoke_credential, verify_credential,
+    IssueCredentialError, RevokeCredentialError,
 };

--- a/contracts/axone-vc/src/translation/credential_rdf.rs
+++ b/contracts/axone-vc/src/translation/credential_rdf.rs
@@ -98,6 +98,25 @@ pub fn decode_nquads_credential(
     let utf8 = str::from_utf8(input).map_err(|_| CredentialDecodingError::InvalidUtf8)?;
     let quads = parse_nquads_quads(utf8.as_bytes())?;
     let dataset = Dataset::from_iter(quads.iter().cloned());
+    let canonical_nquads = canonicalize_dataset(&dataset)?;
+
+    decode_dataset_credential(&quads, &dataset, canonical_nquads)
+}
+
+pub(crate) fn decode_canonical_nquads_credential(
+    input: &str,
+) -> Result<DecodedCredential, CredentialDecodingError> {
+    let quads = parse_nquads_quads(input.as_bytes())?;
+    let dataset = Dataset::from_iter(quads.iter().cloned());
+
+    decode_dataset_credential(&quads, &dataset, input.to_string())
+}
+
+fn decode_dataset_credential(
+    quads: &[Quad],
+    dataset: &Dataset,
+    canonical_nquads: String,
+) -> Result<DecodedCredential, CredentialDecodingError> {
     let credential_subject = find_credential_subject(&dataset)?;
     let id = subject_to_identifier(&credential_subject);
     let issuer = extract_issuer(&dataset, &credential_subject)?;
@@ -105,7 +124,6 @@ pub fn decode_nquads_credential(
     let valid_until = extract_validity_bound(&quads, &credential_subject, VC_VALID_UNTIL)?;
     let subject_id = extract_subject_id(&dataset, &credential_subject)?;
     let types = extract_types(&dataset, &credential_subject);
-    let canonical_nquads = canonicalize_dataset(&dataset)?;
 
     Ok(
         DecodedCredential::new(id, issuer, subject_id, types, canonical_nquads)
@@ -125,7 +143,7 @@ fn parse_nquads_quads(input: &[u8]) -> Result<Vec<Quad>, CredentialDecodingError
         .map_err(|_| CredentialDecodingError::InvalidNQuads)
 }
 
-fn find_credential_subject(dataset: &Dataset) -> Result<Subject, CredentialDecodingError> {
+pub fn find_credential_subject(dataset: &Dataset) -> Result<Subject, CredentialDecodingError> {
     let candidate_subjects: HashSet<Subject> = [
         VC_ISSUER,
         VC_VALID_FROM,
@@ -149,7 +167,7 @@ fn find_credential_subject(dataset: &Dataset) -> Result<Subject, CredentialDecod
     Ok(subject)
 }
 
-fn subject_to_identifier(subject: &Subject) -> Option<String> {
+pub fn subject_to_identifier(subject: &Subject) -> Option<String> {
     match subject {
         Subject::NamedNode(node) => Some(node.as_str().to_string()),
         Subject::BlankNode(_) => None,

--- a/contracts/axone-vc/src/translation/credential_rdf.rs
+++ b/contracts/axone-vc/src/translation/credential_rdf.rs
@@ -10,6 +10,8 @@ use std::{collections::HashSet, str};
 use thiserror::Error;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
+pub(crate) type DecodedQuad = Quad;
+
 const VC_ISSUER: NamedNodeRef<'static> =
     NamedNodeRef::new_unchecked("https://www.w3.org/2018/credentials#issuer");
 const VC_VALID_FROM: NamedNodeRef<'static> =
@@ -60,6 +62,8 @@ pub struct DecodedCredential {
     types: Vec<String>,
     #[getset(get = "pub(crate)")]
     canonical_nquads: String,
+    #[getset(get = "pub(crate)")]
+    quads: Vec<DecodedQuad>,
 }
 
 impl DecodedCredential {
@@ -78,7 +82,13 @@ impl DecodedCredential {
             subject_id,
             types,
             canonical_nquads,
+            quads: Vec::new(),
         }
+    }
+
+    pub(crate) fn with_quads(mut self, quads: Vec<DecodedQuad>) -> Self {
+        self.quads = quads;
+        self
     }
 
     pub(crate) fn with_validity(
@@ -152,6 +162,7 @@ fn decode_dataset_credential(
 
     Ok(
         DecodedCredential::new(id, issuer, subject_id, types, canonical_nquads)
+            .with_quads(quads.to_vec())
             .with_validity(valid_from, valid_until),
     )
 }

--- a/contracts/axone-vc/src/translation/credential_rdf.rs
+++ b/contracts/axone-vc/src/translation/credential_rdf.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::Timestamp;
 use getset::Getters;
 use oxrdf::{
     vocab::{rdf, xsd},
-    Dataset, Literal, NamedNodeRef, Quad, Subject, Term,
+    Dataset, GraphName, Literal, NamedNode, NamedNodeRef, Quad, Subject, Term,
 };
 use oxttl::NQuadsParser;
 use rdf_canon::canonicalize;
@@ -92,13 +92,38 @@ impl DecodedCredential {
     }
 }
 
-pub fn decode_nquads_credential(
-    input: &[u8],
-) -> Result<DecodedCredential, CredentialDecodingError> {
+#[cfg(test)]
+fn decode_nquads_credential(input: &[u8]) -> Result<DecodedCredential, CredentialDecodingError> {
     let utf8 = str::from_utf8(input).map_err(|_| CredentialDecodingError::InvalidUtf8)?;
     let quads = parse_nquads_quads(utf8.as_bytes())?;
     let dataset = Dataset::from_iter(quads.iter().cloned());
     let canonical_nquads = canonicalize_dataset(&dataset)?;
+
+    decode_dataset_credential(&quads, &dataset, canonical_nquads)
+}
+
+pub fn decode_nquads_credential_for_issuer(
+    input: &[u8],
+    issuer_did: &str,
+) -> Result<DecodedCredential, CredentialDecodingError> {
+    let utf8 = str::from_utf8(input).map_err(|_| CredentialDecodingError::InvalidUtf8)?;
+    let quads = parse_nquads_quads(utf8.as_bytes())?;
+    let mut dataset = Dataset::from_iter(quads.iter().cloned());
+    let credential_subject = find_credential_subject(&dataset)?;
+    let issuer = extract_issuer(&dataset, &credential_subject)?;
+
+    match issuer {
+        DecodedUri::Missing => {
+            insert_issuer(&mut dataset, credential_subject, issuer_did)?;
+        }
+        DecodedUri::Uri(issuer) if issuer == issuer_did => {}
+        DecodedUri::Uri(_) | DecodedUri::Invalid => {
+            return Err(CredentialDecodingError::InvalidDataset);
+        }
+    }
+
+    let canonical_nquads = canonicalize_dataset(&dataset)?;
+    let quads = parse_nquads_quads(canonical_nquads.as_bytes())?;
 
     decode_dataset_credential(&quads, &dataset, canonical_nquads)
 }
@@ -260,6 +285,22 @@ fn collect_objects(dataset: &Dataset, subject: &Subject, predicate: NamedNodeRef
         .collect()
 }
 
+fn insert_issuer(
+    dataset: &mut Dataset,
+    credential_subject: Subject,
+    issuer: &str,
+) -> Result<(), CredentialDecodingError> {
+    let issuer = NamedNode::new(issuer).map_err(|_| CredentialDecodingError::InvalidDataset)?;
+    let quad = Quad::new(
+        credential_subject,
+        VC_ISSUER.into_owned(),
+        issuer,
+        GraphName::DefaultGraph,
+    );
+    dataset.insert(quad.as_ref());
+    Ok(())
+}
+
 fn canonicalize_dataset(dataset: &Dataset) -> Result<String, CredentialDecodingError> {
     canonicalize(dataset).map_err(map_canonicalization_error)
 }
@@ -271,10 +312,10 @@ fn map_canonicalization_error(_: rdf_canon::CanonicalizationError) -> Credential
 #[cfg(test)]
 mod tests {
     use super::{
-        decode_nquads_credential, extract_issuer, extract_subject_id, extract_validity_bound,
-        find_credential_subject, map_canonicalization_error, parse_nquads, parse_nquads_quads,
-        parse_validity_bound, subject_to_identifier, CredentialDecodingError, DecodedUri,
-        VC_ISSUER, VC_VALID_FROM,
+        decode_nquads_credential, decode_nquads_credential_for_issuer, extract_issuer,
+        extract_subject_id, extract_validity_bound, find_credential_subject,
+        map_canonicalization_error, parse_nquads, parse_nquads_quads, parse_validity_bound,
+        subject_to_identifier, CredentialDecodingError, DecodedUri, VC_ISSUER, VC_VALID_FROM,
     };
     use cosmwasm_std::Timestamp;
     use oxrdf::{BlankNode, Literal, NamedNodeRef, Subject};
@@ -384,6 +425,47 @@ mod tests {
         .expect("missing issuer should still decode");
 
         assert_eq!(decoded.issuer(), &DecodedUri::Missing);
+    }
+
+    #[test]
+    fn decode_credential_for_authority_injects_missing_issuer() {
+        let decoded = decode_nquads_credential_for_issuer(
+            format!(
+                r#"<{CREDENTIAL_ID}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}credentialSubject> <did:example:subject> .
+"#
+            )
+            .as_bytes(),
+            AUTHORITY_DID,
+        )
+        .expect("missing issuer should be injected");
+
+        assert_eq!(
+            decoded.issuer(),
+            &DecodedUri::Uri(AUTHORITY_DID.to_string())
+        );
+        assert!(decoded.canonical_nquads().contains(&format!(
+            "<{CREDENTIAL_ID}> <{VC_NAMESPACE}issuer> <{AUTHORITY_DID}> ."
+        )));
+    }
+
+    #[test]
+    fn decode_credential_for_authority_rejects_mismatched_issuer() {
+        let err = decode_nquads_credential_for_issuer(
+            format!(
+                r#"<{CREDENTIAL_ID}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}issuer> <did:example:issuer> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<{CREDENTIAL_ID}> <{VC_NAMESPACE}credentialSubject> <did:example:subject> .
+"#
+            )
+            .as_bytes(),
+            AUTHORITY_DID,
+        )
+        .expect_err("mismatched issuer should fail");
+
+        assert_eq!(err, CredentialDecodingError::InvalidDataset);
     }
 
     #[test]

--- a/contracts/axone-vc/src/translation/credential_rdf.rs
+++ b/contracts/axone-vc/src/translation/credential_rdf.rs
@@ -117,13 +117,13 @@ fn decode_dataset_credential(
     dataset: &Dataset,
     canonical_nquads: String,
 ) -> Result<DecodedCredential, CredentialDecodingError> {
-    let credential_subject = find_credential_subject(&dataset)?;
+    let credential_subject = find_credential_subject(dataset)?;
     let id = subject_to_identifier(&credential_subject);
-    let issuer = extract_issuer(&dataset, &credential_subject)?;
-    let valid_from = extract_validity_bound(&quads, &credential_subject, VC_VALID_FROM)?;
-    let valid_until = extract_validity_bound(&quads, &credential_subject, VC_VALID_UNTIL)?;
-    let subject_id = extract_subject_id(&dataset, &credential_subject)?;
-    let types = extract_types(&dataset, &credential_subject);
+    let issuer = extract_issuer(dataset, &credential_subject)?;
+    let valid_from = extract_validity_bound(quads, &credential_subject, VC_VALID_FROM)?;
+    let valid_until = extract_validity_bound(quads, &credential_subject, VC_VALID_UNTIL)?;
+    let subject_id = extract_subject_id(dataset, &credential_subject)?;
+    let types = extract_types(dataset, &credential_subject);
 
     Ok(
         DecodedCredential::new(id, issuer, subject_id, types, canonical_nquads)

--- a/contracts/axone-vc/src/translation/mod.rs
+++ b/contracts/axone-vc/src/translation/mod.rs
@@ -1,6 +1,6 @@
 mod credential_rdf;
 
-pub use credential_rdf::decode_nquads_credential;
 pub(crate) use credential_rdf::{
-    decode_canonical_nquads_credential, CredentialDecodingError, DecodedCredential, DecodedUri,
+    decode_canonical_nquads_credential, decode_nquads_credential_for_issuer,
+    CredentialDecodingError, DecodedCredential, DecodedUri,
 };

--- a/contracts/axone-vc/src/translation/mod.rs
+++ b/contracts/axone-vc/src/translation/mod.rs
@@ -1,4 +1,6 @@
 mod credential_rdf;
 
 pub use credential_rdf::decode_nquads_credential;
-pub(crate) use credential_rdf::{CredentialDecodingError, DecodedCredential, DecodedUri};
+pub(crate) use credential_rdf::{
+    decode_canonical_nquads_credential, CredentialDecodingError, DecodedCredential, DecodedUri,
+};

--- a/contracts/axone-vc/src/translation/mod.rs
+++ b/contracts/axone-vc/src/translation/mod.rs
@@ -2,5 +2,5 @@ mod credential_rdf;
 
 pub(crate) use credential_rdf::{
     decode_canonical_nquads_credential, decode_nquads_credential_for_issuer,
-    CredentialDecodingError, DecodedCredential, DecodedUri,
+    CredentialDecodingError, DecodedCredential, DecodedQuad, DecodedUri,
 };

--- a/contracts/axone-vc/tests/integration.rs
+++ b/contracts/axone-vc/tests/integration.rs
@@ -1,7 +1,10 @@
 use abstract_app::objects::namespace::Namespace;
 use abstract_client::{AbstractClient, Application};
 use axone_vc::{
-    msg::{AxoneVcExecuteMsgFns, AxoneVcInstantiateMsg, AxoneVcQueryMsgFns, CredentialInputFormat},
+    msg::{
+        AxoneVcExecuteMsgFns, AxoneVcInstantiateMsg, AxoneVcQueryMsgFns, CredentialInputFormat,
+        Quad,
+    },
     AxoneVcInterface, AXONE_NAMESPACE,
 };
 use bech32::{Bech32, Hrp};
@@ -314,15 +317,40 @@ fn credential_query_returns_metadata_and_canonical_rdf() -> anyhow::Result<()> {
         "1970-01-01T00:00:10Z",
         "1970-01-01T00:00:20Z",
     );
-    let expected_quads = format!(
-        r#"<{credential_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
-<{credential_id}> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:subject> .
-<{credential_id}> <https://www.w3.org/2018/credentials#issuer> <{}> .
-<{credential_id}> <https://www.w3.org/2018/credentials#validFrom> "1970-01-01T00:00:10Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
-<{credential_id}> <https://www.w3.org/2018/credentials#validUntil> "1970-01-01T00:00:20Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
-"#,
-        authority.did
-    );
+    let expected_quads = vec![
+        Quad {
+            subject: format!("<{credential_id}>"),
+            predicate: "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>".to_string(),
+            object: "<https://www.w3.org/2018/credentials#VerifiableCredential>".to_string(),
+            graph_name: None,
+        },
+        Quad {
+            subject: format!("<{credential_id}>"),
+            predicate: "<https://www.w3.org/2018/credentials#credentialSubject>".to_string(),
+            object: "<did:example:subject>".to_string(),
+            graph_name: None,
+        },
+        Quad {
+            subject: format!("<{credential_id}>"),
+            predicate: "<https://www.w3.org/2018/credentials#issuer>".to_string(),
+            object: format!("<{}>", authority.did),
+            graph_name: None,
+        },
+        Quad {
+            subject: format!("<{credential_id}>"),
+            predicate: "<https://www.w3.org/2018/credentials#validFrom>".to_string(),
+            object: "\"1970-01-01T00:00:10Z\"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp>"
+                .to_string(),
+            graph_name: None,
+        },
+        Quad {
+            subject: format!("<{credential_id}>"),
+            predicate: "<https://www.w3.org/2018/credentials#validUntil>".to_string(),
+            object: "\"1970-01-01T00:00:20Z\"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp>"
+                .to_string(),
+            graph_name: None,
+        },
+    ];
 
     env.app
         .issue_credential(Binary::from(input), Some(CredentialInputFormat::NQuads))?;

--- a/contracts/axone-vc/tests/integration.rs
+++ b/contracts/axone-vc/tests/integration.rs
@@ -273,6 +273,37 @@ fn credential_raw_returns_the_expected_canonical_representation() -> anyhow::Res
 }
 
 #[test]
+fn credential_raw_includes_inferred_issuer() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    let credential_id = "urn:uuid:credential-raw-with-inferred-issuer";
+    let input = format!(
+        r#"<{credential_id}> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:subject> .
+<{credential_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{credential_id}> <https://www.w3.org/2018/credentials#issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+"#
+    );
+    let expected = format!(
+        r#"<{credential_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{credential_id}> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:subject> .
+<{credential_id}> <https://www.w3.org/2018/credentials#issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<{credential_id}> <https://www.w3.org/2018/credentials#issuer> <{}> .
+"#,
+        authority.did
+    );
+
+    env.app.issue_credential(
+        Binary::from(input.into_bytes()),
+        Some(CredentialInputFormat::NQuads),
+    )?;
+
+    let response = AxoneVcQueryMsgFns::credential_raw(&env.app, credential_id.to_string())?;
+    assert_eq!(response.credential, Binary::from(expected.into_bytes()));
+
+    Ok(())
+}
+
+#[test]
 fn credential_query_returns_metadata_and_canonical_rdf() -> anyhow::Result<()> {
     let env = TestEnv::setup()?;
     let authority = AxoneVcQueryMsgFns::authority(&env.app)?;

--- a/contracts/axone-vc/tests/integration.rs
+++ b/contracts/axone-vc/tests/integration.rs
@@ -273,6 +273,80 @@ fn credential_raw_returns_the_expected_canonical_representation() -> anyhow::Res
 }
 
 #[test]
+fn credential_query_returns_metadata_and_canonical_rdf() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    let credential_id = "urn:uuid:credential-query";
+    let input = credential_payload_with_validity(
+        &authority.did,
+        credential_id,
+        "1970-01-01T00:00:10Z",
+        "1970-01-01T00:00:20Z",
+    );
+    let expected_quads = format!(
+        r#"<{credential_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{credential_id}> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:subject> .
+<{credential_id}> <https://www.w3.org/2018/credentials#issuer> <{}> .
+<{credential_id}> <https://www.w3.org/2018/credentials#validFrom> "1970-01-01T00:00:10Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+<{credential_id}> <https://www.w3.org/2018/credentials#validUntil> "1970-01-01T00:00:20Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+"#,
+        authority.did
+    );
+
+    env.app
+        .issue_credential(Binary::from(input), Some(CredentialInputFormat::NQuads))?;
+
+    let response = AxoneVcQueryMsgFns::credential(&env.app, credential_id.to_string())?;
+
+    assert_eq!(response.identifier, credential_id);
+    assert_eq!(
+        response.types,
+        vec!["https://www.w3.org/2018/credentials#VerifiableCredential"]
+    );
+    assert_eq!(response.issuer, authority.did);
+    assert_eq!(response.subject, "did:example:subject");
+    assert_eq!(response.valid_from, Some(Timestamp::from_seconds(10)));
+    assert_eq!(response.valid_until, Some(Timestamp::from_seconds(20)));
+    assert_eq!(response.quads, expected_quads);
+
+    Ok(())
+}
+
+#[test]
+fn credential_query_rejects_unknown_and_revoked_credentials() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let credential_id = "urn:uuid:credential-query";
+
+    let err = AxoneVcQueryMsgFns::credential(&env.app, credential_id.to_string())
+        .expect_err("unknown credential should be rejected");
+    assert!(
+        format!("{err:?}").contains("credential not found"),
+        "{err:?}"
+    );
+
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+    env.app.issue_credential(
+        Binary::from(credential_payload_with_validity(
+            &authority.did,
+            credential_id,
+            "1970-01-01T00:00:10Z",
+            "1970-01-01T00:00:20Z",
+        )),
+        Some(CredentialInputFormat::NQuads),
+    )?;
+    env.app.revoke_credential(credential_id.to_string())?;
+
+    let err = AxoneVcQueryMsgFns::credential(&env.app, credential_id.to_string())
+        .expect_err("revoked credential should be rejected");
+    assert!(
+        format!("{err:?}").contains("credential not found"),
+        "{err:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn credential_raw_rejects_unknown_and_revoked_credentials() -> anyhow::Result<()> {
     let env = TestEnv::setup()?;
     let credential_id = "urn:uuid:credential-raw";

--- a/docs/axone-vc.md
+++ b/docs/axone-vc.md
@@ -51,7 +51,9 @@ The submitted payload must match the declared `format` and must describe exactly
 
 The credential is accepted only if it provides: - an identifier - either no issuer or an issuer equal to the authority DID exposed by this contract - a subject identifier - at least one type, including `VerifiableCredential` - optional `validFrom` and `validUntil` claims, when present, encoded as `xsd:dateTimeStamp` instants with `validFrom &lt; validUntil`
 
-The submitted payload may omit the issuer. In that case, the contract treats the credential as issued by its authority DID.
+When the submitted payload omits the issuer, the contract adds its authority DID as the credential issuer.
+
+The registered credential therefore always contains the effective issuer.
 
 Issuance fails if the payload format is not supported, if the credential representation cannot be interpreted according to that format, or if a credential with the same identifier has already been issued by this authority.
 
@@ -261,5 +263,5 @@ N-Quads extends N-Triples to represent RDF datasets by allowing an optional four
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`ac159514587baa44`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`b0e41424a881dbde`)*
 ````

--- a/docs/axone-vc.md
+++ b/docs/axone-vc.md
@@ -123,9 +123,9 @@ This query fails when the identifier is unknown or the credential has been revok
 
 ### QueryMsg::credential
 
-Return an active issued credential with its canonical RDF dataset.
+Return an active issued credential with its RDF dataset.
 
-The returned metadata is reconstructed from the credential RDF dataset accepted at issuance. The `quads` field contains the canonical N-Quads string representation stored by this authority.
+The returned metadata is reconstructed from the credential RDF dataset accepted at issuance. The `quads` field contains the canonical dataset as structured RDF quads.
 
 This query fails when the identifier is unknown or the credential has been revoked.
 
@@ -163,15 +163,15 @@ Response returned by `AxoneVcQueryMsg::Authority`.
 
 Response returned by `AxoneVcQueryMsg::Credential`.
 
-| property      | description                                                                                            |
-| ------------- | ------------------------------------------------------------------------------------------------------ |
-| `identifier`  | _(Required.) _ **string**. Credential identifier extracted from the VC `id`.                           |
-| `issuer`      | _(Required.) _ **string**. Authority DID recorded as the credential issuer.                            |
-| `quads`       | _(Required.) _ **string**. Canonical N-Quads string representation of the credential RDF dataset.      |
-| `subject`     | _(Required.) _ **string**. Credential subject identifier.                                              |
-| `types`       | _(Required.) _ **Array&lt;string&gt;**. Credential type URIs extracted from the VC `type` values.      |
-| `valid_from`  | **[Timestamp](#timestamp)\|null**. Optional lower bound of the credential validity interval.           |
-| `valid_until` | **[Timestamp](#timestamp)\|null**. Optional exclusive upper bound of the credential validity interval. |
+| property      | description                                                                                                      |
+| ------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `identifier`  | _(Required.) _ **string**. Credential identifier extracted from the VC `id`.                                     |
+| `issuer`      | _(Required.) _ **string**. Authority DID recorded as the credential issuer.                                      |
+| `quads`       | _(Required.) _ **Array&lt;[Quad](#quad)&gt;**. Canonical credential RDF dataset represented as structured quads. |
+| `subject`     | _(Required.) _ **string**. Credential subject identifier.                                                        |
+| `types`       | _(Required.) _ **Array&lt;string&gt;**. Credential type URIs extracted from the VC `type` values.                |
+| `valid_from`  | **[Timestamp](#timestamp)\|null**. Optional lower bound of the credential validity interval.                     |
+| `valid_until` | **[Timestamp](#timestamp)\|null**. Optional exclusive upper bound of the credential validity interval.           |
 
 ### credential_raw
 
@@ -207,6 +207,17 @@ Supported credential input encodings.
 | variant   | description                                                                                                                                                                                                                                                      |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | undefined | **string**: `n_quads`. UTF-8 RDF dataset serialized as N-Quads.<br /><br />N-Quads extends N-Triples to represent RDF datasets by allowing an optional fourth term that carries the graph name. See the [N-Quads specification](https://www.w3.org/TR/n-quads/). |
+
+### Quad
+
+RDF quad returned by `AxoneVcQueryMsg::Credential`.
+
+| property     | description                                                                                            |
+| ------------ | ------------------------------------------------------------------------------------------------------ |
+| `graph_name` | **string\|null**. RDF graph name serialized with N-Quads term syntax, or `None` for the default graph. |
+| `object`     | _(Required.) _ **string**. RDF object term serialized with N-Quads term syntax.                        |
+| `predicate`  | _(Required.) _ **string**. RDF predicate IRI serialized with N-Quads term syntax.                      |
+| `subject`    | _(Required.) _ **string**. RDF subject term serialized with N-Quads term syntax.                       |
 
 ### Timestamp
 
@@ -250,5 +261,5 @@ N-Quads extends N-Triples to represent RDF datasets by allowing an optional four
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`9700c996ace7178b`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`ac159514587baa44`)*
 ````

--- a/docs/axone-vc.md
+++ b/docs/axone-vc.md
@@ -121,6 +121,19 @@ This query fails when the identifier is unknown or the credential has been revok
 | `credential_raw`            | _(Required.) _ **object**.                                           |
 | `credential_raw.identifier` | _(Required.) _ **string**. Identifier of the credential to retrieve. |
 
+### QueryMsg::credential
+
+Return an active issued credential with its canonical RDF dataset.
+
+The returned metadata is reconstructed from the credential RDF dataset accepted at issuance. The `quads` field contains the canonical N-Quads string representation stored by this authority.
+
+This query fails when the identifier is unknown or the credential has been revoked.
+
+| parameter               | description                                                          |
+| ----------------------- | -------------------------------------------------------------------- |
+| `credential`            | _(Required.) _ **object**.                                           |
+| `credential.identifier` | _(Required.) _ **string**. Identifier of the credential to retrieve. |
+
 ## MigrateMsg
 
 Migrate message.
@@ -145,6 +158,20 @@ Response returned by `AxoneVcQueryMsg::Authority`.
 | property | description                                                                                                                                                                                                                                                                                                                                |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `did`    | _(Required.) _ **string**. The authority DID recognized by this contract.<br /><br />This representation uses the `did:pkh` method over the on-chain address of the host Abstract Account, rendered as a CAIP-compatible canonical Cosmos Bech32 account address.<br /><br />Form:<br /><br />`did:pkh:cosmos:&lt;chain_id&gt;:cosmos1...` |
+
+### credential
+
+Response returned by `AxoneVcQueryMsg::Credential`.
+
+| property      | description                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------ |
+| `identifier`  | _(Required.) _ **string**. Credential identifier extracted from the VC `id`.                           |
+| `issuer`      | _(Required.) _ **string**. Authority DID recorded as the credential issuer.                            |
+| `quads`       | _(Required.) _ **string**. Canonical N-Quads string representation of the credential RDF dataset.      |
+| `subject`     | _(Required.) _ **string**. Credential subject identifier.                                              |
+| `types`       | _(Required.) _ **Array&lt;string&gt;**. Credential type URIs extracted from the VC `type` values.      |
+| `valid_from`  | **[Timestamp](#timestamp)\|null**. Optional lower bound of the credential validity interval.           |
+| `valid_until` | **[Timestamp](#timestamp)\|null**. Optional exclusive upper bound of the credential validity interval. |
 
 ### credential_raw
 
@@ -223,5 +250,5 @@ N-Quads extends N-Triples to represent RDF datasets by allowing an optional four
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`dd24f8a7a1cbe498`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`9700c996ace7178b`)*
 ````


### PR DESCRIPTION
Adds the `Credential` query message, closes #822.

The query takes the credential identifier as parameter and returns the parsed credential with its canonical representation.

As the canonical format present in the state is known valid at issuance we directly implement the `TryFrom<DecodedCredential> for Credential` at the domain layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credential queries that return metadata and the canonical RDF representation.
  * Added support for retrieving credential details, including issuer, subject, types, and validity dates.
* **Bug Fixes**
  * Improved validation for missing or invalid issuers.
  * Credential lookups now clearly reject unknown and revoked credentials.
* **Tests**
  * Expanded coverage for credential decoding, validation, querying, and canonical data responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->