### PR TITLE
feat(vc): add credentials query

### DIFF
--- a/contracts/axone-vc/src/handlers/query.rs
+++ b/contracts/axone-vc/src/handlers/query.rs
@@ -1,10 +1,10 @@
 use crate::{
     contract::{AxoneVc, AxoneVcResult},
     msg::{
-        AuthorityResponse, AxoneVcQueryMsg, CredentialRawResponse, CredentialResponse,
-        Quad as QuadResponse, VerifyCredentialResponse,
+        pagination_limit, AuthorityResponse, AxoneVcQueryMsg, CredentialRawResponse,
+        CredentialResponse, CredentialsResponse, Quad as QuadResponse, VerifyCredentialResponse,
     },
-    services::{authority, credential, credential_raw, verify_credential},
+    services::{authority, credential, credential_raw, credentials, verify_credential},
     translation::DecodedQuad,
 };
 
@@ -29,6 +29,11 @@ pub fn query_handler(
         AxoneVcQueryMsg::Credential { identifier } => {
             to_json_binary(&query_credential(deps, identifier)?)
         }
+        AxoneVcQueryMsg::Credentials {
+            filter,
+            limit,
+            start_after,
+        } => to_json_binary(&query_credentials(deps, filter, limit, start_after)?),
     }
     .map_err(Into::into)
 }
@@ -64,6 +69,25 @@ fn query_credential(deps: Deps<'_>, identifier: String) -> AxoneVcResult<Credent
         valid_from: result.parsed.valid_from(),
         valid_until: result.parsed.valid_until(),
         quads: result.quads.into_iter().map(QuadResponse::from).collect(),
+    })
+}
+
+fn query_credentials(
+    deps: Deps<'_>,
+    filter: crate::msg::CredentialFilter,
+    limit: Option<u32>,
+    start_after: Option<String>,
+) -> AxoneVcResult<CredentialsResponse> {
+    let result = credentials(
+        deps.storage,
+        filter.subject.as_deref(),
+        filter.credential_type.as_deref(),
+        filter.valid_at,
+        pagination_limit(limit),
+        start_after,
+    )?;
+    Ok(CredentialsResponse {
+        identifiers: result,
     })
 }
 

--- a/contracts/axone-vc/src/index.rs
+++ b/contracts/axone-vc/src/index.rs
@@ -1,0 +1,237 @@
+use cosmwasm_std::{
+    from_json, storage_keys::namespace_with_key, Record, StdError, StdResult, Storage,
+};
+use cw_storage_plus::{Index, IndexPrefix, KeyDeserialize, Map, Prefixer, PrimaryKey};
+use serde::{de::DeserializeOwned, Serialize};
+use std::marker::PhantomData;
+
+pub struct OneToManyIndex<'a, IK, T, PK> {
+    index: for<'b> fn(&[u8], &'b T) -> &'b [IK],
+    idx_namespace: &'a [u8],
+    idx_map: Map<Vec<u8>, u32>,
+    pk_namespace: &'a [u8],
+    phantom: PhantomData<PK>,
+}
+
+impl<'a, IK, T, PK> OneToManyIndex<'a, IK, T, PK>
+where
+    T: Serialize + DeserializeOwned + Clone,
+{
+    pub const fn new(
+        idx_fn: for<'b> fn(&[u8], &'b T) -> &'b [IK],
+        pk_namespace: &'a str,
+        idx_namespace: &'static str,
+    ) -> Self {
+        Self {
+            index: idx_fn,
+            idx_namespace: idx_namespace.as_bytes(),
+            idx_map: Map::new(idx_namespace),
+            pk_namespace: pk_namespace.as_bytes(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, IK, T, PK> Index<T> for OneToManyIndex<'a, IK, T, PK>
+where
+    T: Serialize + DeserializeOwned + Clone,
+    IK: Clone + PrimaryKey<'a>,
+{
+    fn save(&self, store: &mut dyn Storage, pk: &[u8], data: &T) -> StdResult<()> {
+        for idx in (self.index)(pk, data) {
+            self.idx_map
+                .save(store, idx.clone().joined_extra_key(pk), &(pk.len() as u32))?;
+        }
+
+        Ok(())
+    }
+
+    fn remove(&self, store: &mut dyn Storage, pk: &[u8], old_data: &T) -> StdResult<()> {
+        for idx in (self.index)(pk, old_data) {
+            self.idx_map.remove(store, idx.clone().joined_extra_key(pk));
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, IK, T, PK> OneToManyIndex<'a, IK, T, PK>
+where
+    PK: PrimaryKey<'a> + KeyDeserialize,
+    T: Serialize + DeserializeOwned + Clone,
+    IK: PrimaryKey<'a> + Prefixer<'a>,
+{
+    pub fn prefix(&self, p: IK) -> IndexPrefix<PK, T, PK> {
+        IndexPrefix::with_deserialization_functions(
+            self.idx_namespace,
+            &p.prefix(),
+            self.pk_namespace,
+            deserialize_one_to_many_kv::<PK, T>,
+            deserialize_one_to_many_v,
+        )
+    }
+}
+
+fn deserialize_one_to_many_v<T: DeserializeOwned>(
+    store: &dyn Storage,
+    pk_namespace: &[u8],
+    kv: Record,
+) -> StdResult<Record<T>> {
+    let (key, pk_len) = kv;
+    let pk_len = from_json::<u32>(pk_len.as_slice())?;
+    let offset = key.len() - pk_len as usize;
+    let pk = &key[offset..];
+    let full_key = namespace_with_key(&[pk_namespace], pk);
+    let value = store
+        .get(&full_key)
+        .ok_or_else(|| StdError::generic_err("pk not found"))?;
+
+    Ok((pk.to_vec(), from_json::<T>(&value)?))
+}
+
+fn deserialize_one_to_many_kv<K: KeyDeserialize, T: DeserializeOwned>(
+    store: &dyn Storage,
+    pk_namespace: &[u8],
+    kv: Record,
+) -> StdResult<(K::Output, T)> {
+    let (key, pk_len) = kv;
+    let pk_len = from_json::<u32>(pk_len.as_slice())?;
+    let offset = key.len() - pk_len as usize;
+    let pk = &key[offset..];
+    let full_key = namespace_with_key(&[pk_namespace], pk);
+    let value = store
+        .get(&full_key)
+        .ok_or_else(|| StdError::generic_err("pk not found"))?;
+
+    Ok((K::from_slice(pk)?, from_json::<T>(&value)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OneToManyIndex;
+    use cosmwasm_std::{testing::MockStorage, Order, StdResult};
+    use cw_storage_plus::{Index, IndexList, IndexedMap};
+    use serde::{Deserialize, Serialize};
+
+    const ITEMS: IndexedMap<&str, Item, ItemIndexes<'static>> = IndexedMap::new(
+        "one_to_many_items",
+        ItemIndexes {
+            tags: OneToManyIndex::new(item_tags, "one_to_many_items", "one_to_many_items__tags"),
+        },
+    );
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    struct Item {
+        name: String,
+        tags: Vec<String>,
+    }
+
+    struct ItemIndexes<'a> {
+        tags: OneToManyIndex<'a, String, Item, String>,
+    }
+
+    impl IndexList<Item> for ItemIndexes<'_> {
+        fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Item>> + '_> {
+            Box::new(vec![&self.tags as &dyn Index<Item>].into_iter())
+        }
+    }
+
+    fn item_tags<'a>(_pk: &[u8], item: &'a Item) -> &'a [String] {
+        &item.tags
+    }
+
+    fn item(name: &str, tags: &[&str]) -> Item {
+        Item {
+            name: name.to_string(),
+            tags: tags.iter().map(|tag| tag.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn prefix_returns_items_for_each_indexed_value() {
+        let mut storage = MockStorage::new();
+
+        ITEMS
+            .save(&mut storage, "alpha", &item("Alpha", &["red", "round"]))
+            .expect("alpha should save");
+        ITEMS
+            .save(&mut storage, "beta", &item("Beta", &["red"]))
+            .expect("beta should save");
+        ITEMS
+            .save(&mut storage, "gamma", &item("Gamma", &["blue"]))
+            .expect("gamma should save");
+
+        let red_items = ITEMS
+            .idx
+            .tags
+            .prefix("red".to_string())
+            .range(&storage, None, None, Order::Ascending)
+            .collect::<StdResult<Vec<_>>>()
+            .expect("red items should load");
+
+        assert_eq!(
+            red_items,
+            vec![
+                ("alpha".to_string(), item("Alpha", &["red", "round"])),
+                ("beta".to_string(), item("Beta", &["red"])),
+            ]
+        );
+    }
+
+    #[test]
+    fn remove_deletes_all_index_entries_for_the_primary_key() {
+        let mut storage = MockStorage::new();
+        let alpha = item("Alpha", &["red", "round"]);
+
+        ITEMS
+            .save(&mut storage, "alpha", &alpha)
+            .expect("alpha should save");
+        ITEMS
+            .remove(&mut storage, "alpha")
+            .expect("alpha should remove");
+
+        for tag in ["red", "round"] {
+            let items = ITEMS
+                .idx
+                .tags
+                .prefix(tag.to_string())
+                .range(&storage, None, None, Order::Ascending)
+                .collect::<StdResult<Vec<_>>>()
+                .expect("items should load");
+            assert!(items.is_empty(), "{tag} index should be empty");
+        }
+    }
+
+    #[test]
+    fn replace_updates_index_entries() {
+        let mut storage = MockStorage::new();
+
+        ITEMS
+            .save(&mut storage, "alpha", &item("Alpha", &["red"]))
+            .expect("alpha should save");
+        ITEMS
+            .save(&mut storage, "alpha", &item("Alpha", &["blue"]))
+            .expect("alpha should update");
+
+        let red_items = ITEMS
+            .idx
+            .tags
+            .prefix("red".to_string())
+            .range(&storage, None, None, Order::Ascending)
+            .collect::<StdResult<Vec<_>>>()
+            .expect("red items should load");
+        let blue_items = ITEMS
+            .idx
+            .tags
+            .prefix("blue".to_string())
+            .range(&storage, None, None, Order::Ascending)
+            .collect::<StdResult<Vec<_>>>()
+            .expect("blue items should load");
+
+        assert!(red_items.is_empty());
+        assert_eq!(
+            blue_items,
+            vec![("alpha".to_string(), item("Alpha", &["blue"]))]
+        );
+    }
+}

--- a/contracts/axone-vc/src/index.rs
+++ b/contracts/axone-vc/src/index.rs
@@ -234,4 +234,124 @@ mod tests {
             vec![("alpha".to_string(), item("Alpha", &["blue"]))]
         );
     }
+
+    #[test]
+    fn empty_index_values_create_no_entries() {
+        let mut storage = MockStorage::new();
+
+        ITEMS
+            .save(&mut storage, "alpha", &item("Alpha", &[]))
+            .expect("alpha should save");
+
+        let indexed_items = ITEMS
+            .idx
+            .tags
+            .prefix("red".to_string())
+            .range(&storage, None, None, Order::Ascending)
+            .collect::<StdResult<Vec<_>>>()
+            .expect("items should load");
+
+        assert!(indexed_items.is_empty());
+    }
+
+    #[test]
+    fn duplicate_index_values_create_one_entry_per_primary_key() {
+        let mut storage = MockStorage::new();
+
+        ITEMS
+            .save(&mut storage, "alpha", &item("Alpha", &["red", "red"]))
+            .expect("alpha should save");
+
+        let indexed_items = ITEMS
+            .idx
+            .tags
+            .prefix("red".to_string())
+            .range(&storage, None, None, Order::Ascending)
+            .collect::<StdResult<Vec<_>>>()
+            .expect("items should load");
+
+        assert_eq!(
+            indexed_items,
+            vec![("alpha".to_string(), item("Alpha", &["red", "red"]))]
+        );
+    }
+
+    #[test]
+    fn prefix_respects_bounds_and_order() {
+        let mut storage = MockStorage::new();
+
+        for (pk, value) in [
+            ("alpha", item("Alpha", &["red"])),
+            ("beta", item("Beta", &["red"])),
+            ("gamma", item("Gamma", &["red"])),
+        ] {
+            ITEMS
+                .save(&mut storage, pk, &value)
+                .expect("item should save");
+        }
+
+        let indexed_items = ITEMS
+            .idx
+            .tags
+            .prefix("red".to_string())
+            .range(
+                &storage,
+                Some(cw_storage_plus::Bound::exclusive("alpha".to_string())),
+                None,
+                Order::Descending,
+            )
+            .collect::<StdResult<Vec<_>>>()
+            .expect("items should load");
+
+        assert_eq!(
+            indexed_items,
+            vec![
+                ("gamma".to_string(), item("Gamma", &["red"])),
+                ("beta".to_string(), item("Beta", &["red"])),
+            ]
+        );
+    }
+
+    #[test]
+    fn range_raw_returns_primary_keys_and_items() {
+        let mut storage = MockStorage::new();
+
+        ITEMS
+            .save(&mut storage, "alpha", &item("Alpha", &["red"]))
+            .expect("alpha should save");
+
+        let indexed_items = ITEMS
+            .idx
+            .tags
+            .prefix("red".to_string())
+            .range_raw(&storage, None, None, Order::Ascending)
+            .collect::<StdResult<Vec<_>>>()
+            .expect("items should load");
+
+        assert_eq!(
+            indexed_items,
+            vec![(b"alpha".to_vec(), item("Alpha", &["red"]))]
+        );
+    }
+
+    #[test]
+    fn range_reports_dangling_primary_key() {
+        let mut storage = MockStorage::new();
+
+        ITEMS
+            .save(&mut storage, "alpha", &item("Alpha", &["red"]))
+            .expect("alpha should save");
+        ITEMS.key("alpha").remove(&mut storage);
+
+        let err = ITEMS
+            .idx
+            .tags
+            .prefix("red".to_string())
+            .range(&storage, None, None, Order::Ascending)
+            .next()
+            .expect("index entry should remain")
+            .expect_err("missing primary key should fail");
+
+        assert_eq!(err.to_string(), "Generic error: pk not found");
+    }
 }

--- a/contracts/axone-vc/src/lib.rs
+++ b/contracts/axone-vc/src/lib.rs
@@ -2,6 +2,7 @@ pub mod contract;
 pub mod domain;
 pub mod error;
 mod handlers;
+mod index;
 pub mod msg;
 mod services;
 pub mod state;

--- a/contracts/axone-vc/src/msg.rs
+++ b/contracts/axone-vc/src/msg.rs
@@ -5,6 +5,15 @@ use cosmwasm_std::{Binary, Timestamp};
 
 abstract_app::app_msg_types!(AxoneVc, AxoneVcExecuteMsg, AxoneVcQueryMsg);
 
+pub const MAX_PAGINATION_LIMIT: u32 = 100;
+pub const DEFAULT_PAGINATION_LIMIT: u32 = 50;
+
+pub(crate) fn pagination_limit(limit: Option<u32>) -> usize {
+    limit
+        .unwrap_or(DEFAULT_PAGINATION_LIMIT)
+        .min(MAX_PAGINATION_LIMIT) as usize
+}
+
 /// Instantiate message.
 ///
 /// Instantiating this app attaches a verifiable credential authority to the resource
@@ -147,6 +156,27 @@ pub enum AxoneVcQueryMsg {
         /// Identifier of the credential to retrieve.
         identifier: Uri,
     },
+
+    /// Return active credential identifiers matching all provided filters.
+    ///
+    /// An empty filter returns active credentials issued by this authority,
+    /// ordered by credential identifier and paginated with `start_after`.
+    ///
+    /// Revoked credentials are excluded because they are no longer part of the
+    /// active credential set.
+    #[returns(CredentialsResponse)]
+    Credentials {
+        /// Filters applied conjunctively to the active credential set.
+        filter: CredentialFilter,
+        /// Maximum number of identifiers to return.
+        ///
+        /// When omitted, the contract default is used. Values above the contract
+        /// maximum are capped.
+        limit: Option<u32>,
+        /// Exclusive pagination cursor using a credential identifier returned by
+        /// a previous page.
+        start_after: Option<Uri>,
+    },
 }
 
 /// Response returned by `AxoneVcQueryMsg::Authority`.
@@ -202,6 +232,28 @@ pub struct CredentialResponse {
     pub valid_until: Option<Timestamp>,
     /// Canonical credential RDF dataset represented as structured quads.
     pub quads: Vec<Quad>,
+}
+
+/// Filter accepted by `AxoneVcQueryMsg::Credentials`.
+#[cosmwasm_schema::cw_serde]
+#[derive(Default)]
+pub struct CredentialFilter {
+    /// Credential subject identifier to match.
+    pub subject: Option<Uri>,
+    /// Credential type URI to match against the VC `type` values.
+    pub credential_type: Option<Uri>,
+    /// Instant that must be contained by the credential validity interval.
+    ///
+    /// `validFrom` is inclusive when present, `validUntil` is exclusive when
+    /// present, and missing bounds are treated as unbounded.
+    pub valid_at: Option<Timestamp>,
+}
+
+/// Response returned by `AxoneVcQueryMsg::Credentials`.
+#[cosmwasm_schema::cw_serde]
+pub struct CredentialsResponse {
+    /// Active credential identifiers matching the requested filters.
+    pub identifiers: Vec<Uri>,
 }
 
 /// RDF quad returned by `AxoneVcQueryMsg::Credential`.

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -186,7 +186,7 @@ pub fn credentials(
             Some(t) => Box::new(move |r| match r {
                 Ok((_, c)) => {
                     c.valid_from.map(|from| from <= t).unwrap_or(true)
-                        && c.valid_until.map(|until| t <= until).unwrap_or(true)
+                        && c.valid_until.map(|until| t < until).unwrap_or(true)
                 }
                 Err(_) => true,
             }),
@@ -284,6 +284,38 @@ mod tests {
 "#
         )
         .into_bytes()
+    }
+
+    fn credential_payload_with_metadata(
+        authority_did: &str,
+        id: &str,
+        subject: &str,
+        extra_types: &[&str],
+        validity: Option<(&str, &str)>,
+    ) -> Vec<u8> {
+        let mut payload = format!(
+            r#"<{id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{id}> <https://www.w3.org/2018/credentials#issuer> <{authority_did}> .
+<{id}> <https://www.w3.org/2018/credentials#issuanceDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<{id}> <https://www.w3.org/2018/credentials#credentialSubject> <{subject}> .
+"#
+        );
+
+        for credential_type in extra_types {
+            payload.push_str(&format!(
+                "<{id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{credential_type}> .\n"
+            ));
+        }
+
+        if let Some((valid_from, valid_until)) = validity {
+            payload.push_str(&format!(
+                r#"<{id}> <https://www.w3.org/2018/credentials#validFrom> "{valid_from}"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+<{id}> <https://www.w3.org/2018/credentials#validUntil> "{valid_until}"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+"#
+            ));
+        }
+
+        payload.into_bytes()
     }
 
     fn initialized_authority(
@@ -546,6 +578,203 @@ mod tests {
         let err = credential(deps.as_ref().storage, credential_id)
             .expect_err("revoked credential should fail");
         assert!(err.to_string().contains("credential not found"));
+    }
+
+    #[test]
+    fn credentials_returns_empty_list_without_credentials_and_with_zero_limit() {
+        let mut deps = mock_dependencies();
+        let authority = initialized_authority(&mut deps);
+
+        assert_eq!(
+            credentials(deps.as_ref().storage, None, None, None, 10, None)
+                .expect("credentials query should succeed"),
+            Vec::<String>::new()
+        );
+
+        issue_credential(
+            deps.as_mut().storage,
+            &credential_payload(authority.did(), "urn:uuid:credential-1"),
+            CredentialInputFormat::NQuads,
+        )
+        .expect("credential should issue");
+
+        assert_eq!(
+            credentials(deps.as_ref().storage, None, None, None, 0, None)
+                .expect("credentials query should succeed"),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn credentials_paginates_identifiers_in_ascending_order() {
+        let mut deps = mock_dependencies();
+        let authority = initialized_authority(&mut deps);
+
+        for id in [
+            "urn:uuid:credential-c",
+            "urn:uuid:credential-a",
+            "urn:uuid:credential-b",
+        ] {
+            issue_credential(
+                deps.as_mut().storage,
+                &credential_payload(authority.did(), id),
+                CredentialInputFormat::NQuads,
+            )
+            .expect("credential should issue");
+        }
+
+        assert_eq!(
+            credentials(deps.as_ref().storage, None, None, None, 2, None)
+                .expect("first page should load"),
+            vec!["urn:uuid:credential-a", "urn:uuid:credential-b"]
+        );
+        assert_eq!(
+            credentials(
+                deps.as_ref().storage,
+                None,
+                None,
+                None,
+                2,
+                Some("urn:uuid:credential-b".to_string())
+            )
+            .expect("second page should load"),
+            vec!["urn:uuid:credential-c"]
+        );
+    }
+
+    #[test]
+    fn credentials_filters_by_subject_type_and_validity() {
+        let mut deps = mock_dependencies();
+        let authority = initialized_authority(&mut deps);
+
+        for payload in [
+            credential_payload_with_metadata(
+                authority.did(),
+                "urn:uuid:credential-a",
+                "did:example:alice",
+                &["https://example.com/types/Employee"],
+                Some(("1970-01-01T00:00:10Z", "1970-01-01T00:00:20Z")),
+            ),
+            credential_payload_with_metadata(
+                authority.did(),
+                "urn:uuid:credential-b",
+                "did:example:bob",
+                &["https://example.com/types/Member"],
+                None,
+            ),
+            credential_payload_with_metadata(
+                authority.did(),
+                "urn:uuid:credential-c",
+                "did:example:alice",
+                &["https://example.com/types/Member"],
+                Some(("1970-01-01T00:00:20Z", "1970-01-01T00:00:30Z")),
+            ),
+            credential_payload_with_metadata(
+                authority.did(),
+                "urn:uuid:credential-d",
+                "did:example:alice",
+                &["https://example.com/types/Employee"],
+                None,
+            ),
+        ] {
+            issue_credential(
+                deps.as_mut().storage,
+                &payload,
+                CredentialInputFormat::NQuads,
+            )
+            .expect("credential should issue");
+        }
+
+        assert_eq!(
+            credentials(
+                deps.as_ref().storage,
+                Some("did:example:alice"),
+                None,
+                None,
+                10,
+                None
+            )
+            .expect("subject filter should load"),
+            vec![
+                "urn:uuid:credential-a",
+                "urn:uuid:credential-c",
+                "urn:uuid:credential-d"
+            ]
+        );
+        assert_eq!(
+            credentials(
+                deps.as_ref().storage,
+                None,
+                Some("https://example.com/types/Member"),
+                None,
+                10,
+                None
+            )
+            .expect("type filter should load"),
+            vec!["urn:uuid:credential-b", "urn:uuid:credential-c"]
+        );
+        assert_eq!(
+            credentials(
+                deps.as_ref().storage,
+                Some("did:example:alice"),
+                Some("https://example.com/types/Member"),
+                Some(Timestamp::from_seconds(25)),
+                10,
+                None
+            )
+            .expect("combined filters should load"),
+            vec!["urn:uuid:credential-c"]
+        );
+        assert_eq!(
+            credentials(
+                deps.as_ref().storage,
+                None,
+                None,
+                Some(Timestamp::from_seconds(20)),
+                10,
+                None
+            )
+            .expect("validity filter should load"),
+            vec![
+                "urn:uuid:credential-b",
+                "urn:uuid:credential-c",
+                "urn:uuid:credential-d"
+            ]
+        );
+    }
+
+    #[test]
+    fn credentials_excludes_revoked_credentials_from_indexes() {
+        let mut deps = mock_dependencies();
+        let authority = initialized_authority(&mut deps);
+
+        issue_credential(
+            deps.as_mut().storage,
+            &credential_payload_with_metadata(
+                authority.did(),
+                "urn:uuid:credential-a",
+                "did:example:alice",
+                &["https://example.com/types/Member"],
+                None,
+            ),
+            CredentialInputFormat::NQuads,
+        )
+        .expect("credential should issue");
+        revoke_credential(deps.as_mut().storage, "urn:uuid:credential-a")
+            .expect("credential should revoke");
+
+        assert_eq!(
+            credentials(
+                deps.as_ref().storage,
+                Some("did:example:alice"),
+                Some("https://example.com/types/Member"),
+                None,
+                10,
+                None
+            )
+            .expect("credentials query should succeed"),
+            Vec::<String>::new()
+        );
     }
 
     #[test]

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -85,10 +85,15 @@ fn issue_credential_with_authority(
         return Err(IssueCredentialError::CredentialRevoked);
     }
 
-    Ok((
-        credential,
-        CredentialRecord::new(canonical_nquads, valid_from, valid_until),
-    ))
+    let record = CredentialRecord::new(
+        canonical_nquads,
+        credential.subject_id().clone(),
+        credential.types().clone(),
+        valid_from,
+        valid_until,
+    );
+
+    Ok((credential, record))
 }
 
 #[derive(Debug, PartialEq)]

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -1,3 +1,4 @@
+use crate::domain::Uri;
 use crate::{
     contract::AxoneVcResult,
     domain::{Credential, CredentialError},
@@ -5,15 +6,16 @@ use crate::{
     services::authority,
     state,
     state::{
-        credential as stored_credential, has_credential, is_revoked, record_credential,
-        CredentialRecord, CredentialTombstone,
+        credential as stored_credential, credentials as stored_credentials, credentials_by_subject,
+        credentials_by_type, has_credential, is_revoked, record_credential, CredentialRecord,
+        CredentialTombstone,
     },
     translation::{
         decode_canonical_nquads_credential, decode_nquads_credential_for_issuer,
         CredentialDecodingError, DecodedQuad,
     },
 };
-use cosmwasm_std::{Binary, StdError, Storage, Timestamp};
+use cosmwasm_std::{Binary, StdError, StdResult, Storage, Timestamp};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq)]
@@ -147,6 +149,55 @@ pub fn credential(storage: &dyn Storage, credential_id: &str) -> AxoneVcResult<C
     let parsed = Credential::try_from(decoded)?;
 
     Ok(CredentialResult { parsed, quads })
+}
+
+pub fn credentials(
+    storage: &dyn Storage,
+    subject: Option<&str>,
+    credential_type: Option<&str>,
+    valid_at: Option<Timestamp>,
+    limit: usize,
+    start_after: Option<String>,
+) -> AxoneVcResult<Vec<Uri>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let it = match (subject, credential_type) {
+        (Some(subject), _) => credentials_by_subject(storage, subject, start_after.as_deref()),
+        (None, Some(ctype)) => credentials_by_type(storage, ctype, start_after.as_deref()),
+        (None, None) => stored_credentials(storage, start_after.as_deref()),
+    };
+
+    let type_filter: Box<dyn FnMut(&StdResult<(String, CredentialRecord)>) -> bool> =
+        match credential_type {
+            Some(t) => {
+                let t = t.to_owned();
+                Box::new(move |r| match r {
+                    Ok((_, c)) => c.types.contains(&t),
+                    Err(_) => true,
+                })
+            }
+            None => Box::new(|_| true),
+        };
+
+    let valid_filter: Box<dyn FnMut(&StdResult<(String, CredentialRecord)>) -> bool> =
+        match valid_at {
+            Some(t) => Box::new(move |r| match r {
+                Ok((_, c)) => {
+                    c.valid_from.map(|from| from <= t).unwrap_or(true)
+                        && c.valid_until.map(|until| t <= until).unwrap_or(true)
+                }
+                Err(_) => true,
+            }),
+            None => Box::new(|_| true),
+        };
+
+    it.filter(type_filter)
+        .filter(valid_filter)
+        .take(limit)
+        .map(|item| item.map(|(id, _record)| id).map_err(Into::into))
+        .collect::<AxoneVcResult<Vec<_>>>()
 }
 
 #[derive(Debug, PartialEq)]

--- a/contracts/axone-vc/src/services/credential.rs
+++ b/contracts/axone-vc/src/services/credential.rs
@@ -169,29 +169,28 @@ pub fn credentials(
         (None, None) => stored_credentials(storage, start_after.as_deref()),
     };
 
-    let type_filter: Box<dyn FnMut(&StdResult<(String, CredentialRecord)>) -> bool> =
-        match credential_type {
-            Some(t) => {
-                let t = t.to_owned();
-                Box::new(move |r| match r {
-                    Ok((_, c)) => c.types.contains(&t),
-                    Err(_) => true,
-                })
-            }
-            None => Box::new(|_| true),
-        };
-
-    let valid_filter: Box<dyn FnMut(&StdResult<(String, CredentialRecord)>) -> bool> =
-        match valid_at {
-            Some(t) => Box::new(move |r| match r {
-                Ok((_, c)) => {
-                    c.valid_from.map(|from| from <= t).unwrap_or(true)
-                        && c.valid_until.map(|until| t < until).unwrap_or(true)
-                }
+    type FilterPredicate = Box<dyn FnMut(&StdResult<(String, CredentialRecord)>) -> bool>;
+    let type_filter: FilterPredicate = match credential_type {
+        Some(t) => {
+            let t = t.to_owned();
+            Box::new(move |r| match r {
+                Ok((_, c)) => c.types.contains(&t),
                 Err(_) => true,
-            }),
-            None => Box::new(|_| true),
-        };
+            })
+        }
+        None => Box::new(|_| true),
+    };
+
+    let valid_filter: FilterPredicate = match valid_at {
+        Some(t) => Box::new(move |r| match r {
+            Ok((_, c)) => {
+                c.valid_from.is_none_or(|from| from <= t)
+                    && c.valid_until.is_none_or(|until| t < until)
+            }
+            Err(_) => true,
+        }),
+        None => Box::new(|_| true),
+    };
 
     it.filter(type_filter)
         .filter(valid_filter)

--- a/contracts/axone-vc/src/services/mod.rs
+++ b/contracts/axone-vc/src/services/mod.rs
@@ -3,6 +3,6 @@ mod credential;
 
 pub use authority::{authority, initialize_authority};
 pub use credential::{
-    credential, credential_raw, issue_credential, revoke_credential, verify_credential,
-    IssueCredentialError, RevokeCredentialError,
+    credential, credential_raw, credentials, issue_credential, revoke_credential,
+    verify_credential, IssueCredentialError, RevokeCredentialError,
 };

--- a/contracts/axone-vc/src/state.rs
+++ b/contracts/axone-vc/src/state.rs
@@ -1,13 +1,41 @@
 use crate::domain::Authority;
 use crate::error::AxoneVcError;
+use crate::index::OneToManyIndex;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{StdError, Storage, Timestamp};
-use cw_storage_plus::{Item, Map};
+use cosmwasm_std::{Order, StdError, StdResult, Storage, Timestamp};
+use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Item, Map, MultiIndex};
 
 const AUTHORITY: Item<Authority> = Item::new("authority");
-const CREDENTIALS: Map<&str, CredentialRecord> = Map::new("credentials");
 const REVOKED_CREDENTIALS: Map<&str, CredentialTombstone> = Map::new("revoked_credentials");
+
+const CREDENTIALS: IndexedMap<&str, CredentialRecord, CredentialIndexes<'static>> = IndexedMap::new(
+    "credentials",
+    CredentialIndexes {
+        subject: MultiIndex::new(
+            |_, r| r.subject.clone(),
+            "credentials",
+            "credentials__subject",
+        ),
+        credential_type: OneToManyIndex::new(
+            |_, r| r.types.as_slice(),
+            "credentials",
+            "credentials__type",
+        ),
+    },
+);
+
+pub struct CredentialIndexes<'a> {
+    pub subject: MultiIndex<'a, String, CredentialRecord, &'a str>,
+    pub credential_type: OneToManyIndex<'a, String, CredentialRecord, &'a str>,
+}
+
+impl IndexList<CredentialRecord> for CredentialIndexes<'_> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<CredentialRecord>> + '_> {
+        let indexes: Vec<&dyn Index<CredentialRecord>> = vec![&self.subject, &self.credential_type];
+        Box::new(indexes.into_iter())
+    }
+}
 
 #[cw_serde]
 pub struct CredentialRecord {
@@ -95,7 +123,7 @@ pub fn revoke_credential(
     credential_id: &str,
     tombstone: &CredentialTombstone,
 ) -> Result<(), AxoneVcError> {
-    CREDENTIALS.remove(storage, credential_id);
+    CREDENTIALS.remove(storage, credential_id)?;
     REVOKED_CREDENTIALS.save(storage, credential_id, tombstone)?;
     Ok(())
 }
@@ -119,6 +147,8 @@ mod tests {
         let record: CredentialRecord = from_json(br#"{"canonical_nquads":"<credential>"}"#)
             .expect("legacy credential record should deserialize");
 
+        assert_eq!(record.subject, "");
+        assert!(record.types.is_empty());
         assert_eq!(record.valid_from, None);
         assert_eq!(record.valid_until, None);
     }

--- a/contracts/axone-vc/src/state.rs
+++ b/contracts/axone-vc/src/state.rs
@@ -114,6 +114,45 @@ pub fn record_credential(
     Ok(())
 }
 
+pub fn credentials<'a>(
+    storage: &'a dyn Storage,
+    start_after: Option<&'a str>,
+) -> Box<dyn Iterator<Item = StdResult<(String, CredentialRecord)>> + 'a> {
+    let start = start_after.map(Bound::exclusive);
+
+    CREDENTIALS.range(storage, start, None, Order::Ascending)
+}
+
+pub fn credentials_by_subject<'a>(
+    storage: &'a dyn Storage,
+    subject: &'a str,
+    start_after: Option<&'a str>,
+) -> Box<dyn Iterator<Item = StdResult<(String, CredentialRecord)>> + 'a> {
+    CREDENTIALS.idx.subject.prefix(subject.to_string()).range(
+        storage,
+        start_after.map(Bound::exclusive),
+        None,
+        Order::Ascending,
+    )
+}
+
+pub fn credentials_by_type<'a>(
+    storage: &'a dyn Storage,
+    credential_type: &'a str,
+    start_after: Option<&'a str>,
+) -> Box<dyn Iterator<Item = StdResult<(String, CredentialRecord)>> + 'a> {
+    CREDENTIALS
+        .idx
+        .credential_type
+        .prefix(credential_type.to_string())
+        .range(
+            storage,
+            start_after.map(Bound::exclusive),
+            None,
+            Order::Ascending,
+        )
+}
+
 pub fn is_revoked(storage: &dyn Storage, credential_id: &str) -> bool {
     REVOKED_CREDENTIALS.has(storage, credential_id)
 }

--- a/contracts/axone-vc/src/state.rs
+++ b/contracts/axone-vc/src/state.rs
@@ -13,6 +13,10 @@ const REVOKED_CREDENTIALS: Map<&str, CredentialTombstone> = Map::new("revoked_cr
 pub struct CredentialRecord {
     pub canonical_nquads: String,
     #[serde(default)]
+    pub subject: String,
+    #[serde(default)]
+    pub types: Vec<String>,
+    #[serde(default)]
     pub valid_from: Option<Timestamp>,
     #[serde(default)]
     pub valid_until: Option<Timestamp>,
@@ -21,11 +25,15 @@ pub struct CredentialRecord {
 impl CredentialRecord {
     pub fn new(
         canonical_nquads: String,
+        subject: String,
+        types: Vec<String>,
         valid_from: Option<Timestamp>,
         valid_until: Option<Timestamp>,
     ) -> Self {
         Self {
             canonical_nquads,
+            subject,
+            types,
             valid_from,
             valid_until,
         }

--- a/contracts/axone-vc/tests/integration.rs
+++ b/contracts/axone-vc/tests/integration.rs
@@ -2,8 +2,8 @@ use abstract_app::objects::namespace::Namespace;
 use abstract_client::{AbstractClient, Application};
 use axone_vc::{
     msg::{
-        AxoneVcExecuteMsgFns, AxoneVcInstantiateMsg, AxoneVcQueryMsgFns, CredentialInputFormat,
-        Quad,
+        AxoneVcExecuteMsgFns, AxoneVcInstantiateMsg, AxoneVcQueryMsgFns, CredentialFilter,
+        CredentialInputFormat, Quad,
     },
     AxoneVcInterface, AXONE_NAMESPACE,
 };
@@ -406,6 +406,156 @@ fn credential_query_rejects_unknown_and_revoked_credentials() -> anyhow::Result<
 }
 
 #[test]
+fn credentials_query_returns_empty_list_without_credentials() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+
+    let response =
+        AxoneVcQueryMsgFns::credentials(&env.app, CredentialFilter::default(), None, None)?;
+
+    assert!(response.identifiers.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn credentials_query_filters_and_paginates_identifiers() -> anyhow::Result<()> {
+    let env = TestEnv::setup()?;
+    let authority = AxoneVcQueryMsgFns::authority(&env.app)?;
+
+    for credential in [
+        credential_payload(
+            &authority.did,
+            "urn:uuid:credential-c",
+            "did:example:alice",
+            &["https://example.com/types/Member"],
+            Some(("1970-01-01T00:00:20Z", "1970-01-01T00:00:30Z")),
+        ),
+        credential_payload(
+            &authority.did,
+            "urn:uuid:credential-a",
+            "did:example:alice",
+            &["https://example.com/types/Employee"],
+            Some(("1970-01-01T00:00:10Z", "1970-01-01T00:00:20Z")),
+        ),
+        credential_payload(
+            &authority.did,
+            "urn:uuid:credential-b",
+            "did:example:bob",
+            &["https://example.com/types/Member"],
+            None,
+        ),
+        credential_payload(
+            &authority.did,
+            "urn:uuid:credential-d",
+            "did:example:alice",
+            &["https://example.com/types/Employee"],
+            None,
+        ),
+    ] {
+        env.app.issue_credential(
+            Binary::from(credential),
+            Some(CredentialInputFormat::NQuads),
+        )?;
+    }
+
+    let page =
+        AxoneVcQueryMsgFns::credentials(&env.app, CredentialFilter::default(), Some(2), None)?;
+    assert_eq!(
+        page.identifiers,
+        vec!["urn:uuid:credential-a", "urn:uuid:credential-b"]
+    );
+
+    let page = AxoneVcQueryMsgFns::credentials(
+        &env.app,
+        CredentialFilter::default(),
+        Some(2),
+        Some("urn:uuid:credential-b".to_string()),
+    )?;
+    assert_eq!(
+        page.identifiers,
+        vec!["urn:uuid:credential-c", "urn:uuid:credential-d"]
+    );
+
+    let response = AxoneVcQueryMsgFns::credentials(
+        &env.app,
+        CredentialFilter {
+            subject: Some("did:example:alice".to_string()),
+            ..Default::default()
+        },
+        None,
+        None,
+    )?;
+    assert_eq!(
+        response.identifiers,
+        vec![
+            "urn:uuid:credential-a",
+            "urn:uuid:credential-c",
+            "urn:uuid:credential-d"
+        ]
+    );
+
+    let response = AxoneVcQueryMsgFns::credentials(
+        &env.app,
+        CredentialFilter {
+            credential_type: Some("https://example.com/types/Member".to_string()),
+            ..Default::default()
+        },
+        None,
+        None,
+    )?;
+    assert_eq!(
+        response.identifiers,
+        vec!["urn:uuid:credential-b", "urn:uuid:credential-c"]
+    );
+
+    let response = AxoneVcQueryMsgFns::credentials(
+        &env.app,
+        CredentialFilter {
+            valid_at: Some(Timestamp::from_seconds(15)),
+            ..Default::default()
+        },
+        None,
+        None,
+    )?;
+    assert_eq!(
+        response.identifiers,
+        vec![
+            "urn:uuid:credential-a",
+            "urn:uuid:credential-b",
+            "urn:uuid:credential-d"
+        ]
+    );
+
+    let response = AxoneVcQueryMsgFns::credentials(
+        &env.app,
+        CredentialFilter {
+            subject: Some("did:example:alice".to_string()),
+            credential_type: Some("https://example.com/types/Member".to_string()),
+            valid_at: Some(Timestamp::from_seconds(25)),
+        },
+        None,
+        None,
+    )?;
+    assert_eq!(response.identifiers, vec!["urn:uuid:credential-c"]);
+
+    env.app
+        .revoke_credential("urn:uuid:credential-c".to_string())?;
+    let response = AxoneVcQueryMsgFns::credentials(
+        &env.app,
+        CredentialFilter {
+            subject: Some("did:example:alice".to_string()),
+            credential_type: Some("https://example.com/types/Member".to_string()),
+            ..Default::default()
+        },
+        None,
+        None,
+    )?;
+    assert!(response.identifiers.is_empty());
+
+    Ok(())
+}
+
+#[test]
 fn credential_raw_rejects_unknown_and_revoked_credentials() -> anyhow::Result<()> {
     let env = TestEnv::setup()?;
     let credential_id = "urn:uuid:credential-raw";
@@ -597,4 +747,35 @@ fn credential_payload_with_validity(
 "#
     )
     .into_bytes()
+}
+
+fn credential_payload(
+    authority_did: &str,
+    credential_id: &str,
+    subject: &str,
+    extra_types: &[&str],
+    validity: Option<(&str, &str)>,
+) -> Vec<u8> {
+    let mut payload = format!(
+        r#"<{credential_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<{credential_id}> <https://www.w3.org/2018/credentials#issuer> <{authority_did}> .
+<{credential_id}> <https://www.w3.org/2018/credentials#credentialSubject> <{subject}> .
+"#
+    );
+
+    for credential_type in extra_types {
+        payload.push_str(&format!(
+            "<{credential_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{credential_type}> .\n"
+        ));
+    }
+
+    if let Some((valid_from, valid_until)) = validity {
+        payload.push_str(&format!(
+            r#"<{credential_id}> <https://www.w3.org/2018/credentials#validFrom> "{valid_from}"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+<{credential_id}> <https://www.w3.org/2018/credentials#validUntil> "{valid_until}"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> .
+"#
+        ));
+    }
+
+    payload.into_bytes()
 }

--- a/docs/axone-vc.md
+++ b/docs/axone-vc.md
@@ -136,6 +136,21 @@ This query fails when the identifier is unknown or the credential has been revok
 | `credential`            | _(Required.) _ **object**.                                           |
 | `credential.identifier` | _(Required.) _ **string**. Identifier of the credential to retrieve. |
 
+### QueryMsg::credentials
+
+Return active credential identifiers matching all provided filters.
+
+An empty filter returns active credentials issued by this authority, ordered by credential identifier and paginated with `start_after`.
+
+Revoked credentials are excluded because they are no longer part of the active credential set.
+
+| parameter                 | description                                                                                                                                                      |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `credentials`             | _(Required.) _ **object**.                                                                                                                                       |
+| `credentials.filter`      | _(Required.) _ **[CredentialFilter](#credentialfilter)**. Filters applied conjunctively to the active credential set.                                            |
+| `credentials.limit`       | **integer\|null**. Maximum number of identifiers to return.<br /><br />When omitted, the contract default is used. Values above the contract maximum are capped. |
+| `credentials.start_after` | **string\|null**. Exclusive pagination cursor using a credential identifier returned by a previous page.                                                         |
+
 ## MigrateMsg
 
 Migrate message.
@@ -183,6 +198,14 @@ Response returned by `AxoneVcQueryMsg::CredentialRaw`.
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `credential` | _(Required.) _ **[Binary](#binary)**. Canonical serialized credential representation persisted by the contract.<br /><br />This binary value is base64-encoded in JSON responses and is independent from the format and presentation of the credential submitted at issuance. |
 
+### credentials
+
+Response returned by `AxoneVcQueryMsg::Credentials`.
+
+| property      | description                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| `identifiers` | _(Required.) _ **Array&lt;string&gt;**. Active credential identifiers matching the requested filters. |
+
 ### verify_credential
 
 Response returned by `AxoneVcQueryMsg::VerifyCredential`.
@@ -201,6 +224,16 @@ A string containing Base64-encoded data.
 | type        |
 | ----------- |
 | **string**. |
+
+### CredentialFilter
+
+Filter accepted by `AxoneVcQueryMsg::Credentials`.
+
+| property          | description                                                                                                                                                                                                                                   |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `credential_type` | **string\|null**. Credential type URI to match against the VC `type` values.                                                                                                                                                                  |
+| `subject`         | **string\|null**. Credential subject identifier to match.                                                                                                                                                                                     |
+| `valid_at`        | **[Timestamp](#timestamp)\|null**. Instant that must be contained by the credential validity interval.<br /><br />`validFrom` is inclusive when present, `validUntil` is exclusive when present, and missing bounds are treated as unbounded. |
 
 ### CredentialInputFormat
 
@@ -263,5 +296,5 @@ N-Quads extends N-Triples to represent RDF datasets by allowing an optional four
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`b0e41424a881dbde`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-vc.json` (`fd0c7f3e46a589f3`)*
 ````


### PR DESCRIPTION
Add the `Credentials` query message to fetch filtered and paginated credential identifiers, closes #824.

## Details

Some state changes are worth mentioning here: as filtering is allowed on subject / type / validity I've decided to index credentials on subjects and types, which means the `CREDENTIALS` state map is now an `IndexedMap`.

As a credential can be of multiple types, I've introduced a new cw-storage-plus `Index` impl to manage this one to many case: `OneToManyIndex`.

In order to index credentials on these fields the `CredentialRecord` now carries copies of them.

This results in more effective queries but at the cost of more issuance gas & storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a credentials query with filtering by subject, credential type, and validity date.
  * Added pagination support with configurable limits and cursor-based navigation.
  * Credential listings now return active credential identifiers in ascending order.
  * Revoked credentials are excluded from query results.

* **Bug Fixes**
  * Improved credential storage and indexing for reliable filtering and lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->