### PR TITLE
✨ feat(gov): record revision authorization

### DIFF
--- a/contracts/axone-gov/README.md
+++ b/contracts/axone-gov/README.md
@@ -61,11 +61,14 @@ A constitutional revision is performed by submitting an execution message that:
 
 1. Proposes a new constitution
 2. Evaluates the **current** constitution on a case containing the intent `gov:revise_constitution`
+3. Evaluates the **proposed** constitution on the constitutive intent `gov:establish`
 
-The revision is applied **only if** the verdict returned by the constitution is exactly:
+The revision is applied only when both decisions return:
 
 ```prolog
 gov:permitted
 ```
 
-Any other verdict (atom or compound term) results in a refusal.
+The authorization returned by the current constitution is recorded as a decision with that
+constitution's revision and hash. The decision record and revised constitution are committed in
+the same transaction, so a refused or failed revision records neither.

--- a/contracts/axone-gov/src/handlers/execute.rs
+++ b/contracts/axone-gov/src/handlers/execute.rs
@@ -93,6 +93,19 @@ fn execute_revise_constitution(
         });
     }
 
+    record_decision(
+        deps.storage,
+        Decision::new(
+            &current_status,
+            current_case.to_string(),
+            current_decision.verdict.to_string(),
+            Some(current_decision.motivation.to_string()),
+            info.sender.clone(),
+            env.block.height,
+            env.block.time.seconds(),
+        ),
+    )?;
+
     let status = save_revised_constitution(deps.storage, &revised_constitution)?;
 
     Ok(module.custom_response(

--- a/contracts/axone-gov/src/msg.rs
+++ b/contracts/axone-gov/src/msg.rs
@@ -131,7 +131,9 @@ pub enum AxoneGovExecuteMsg {
     /// }
     /// ```
     ///
-    /// The revision is applied only if both decisions return the verdict `gov:permitted`.
+    /// The revision is applied only if both decisions return the verdict `gov:permitted`. The
+    /// authorization decision returned by the current constitution is recorded with its current
+    /// constitution revision and hash in the same transaction as the constitutional revision.
     ReviseConstitution {
         /// The proposed new constitution (UTF-8 Prolog program bytes).
         constitution: Binary,

--- a/contracts/axone-gov/tests/integration.rs
+++ b/contracts/axone-gov/tests/integration.rs
@@ -32,6 +32,25 @@ fn record_decision_case(case_body: &str) -> String {
     format!("case{{{case_body}, {}}}", record_decision_context())
 }
 
+fn revise_constitution_case(
+    proposed_constitution: &Binary,
+    current_constitution: &Binary,
+    current_revision: u64,
+) -> String {
+    let proposed_hash = atom_literal(&to_hex(
+        Checksum::generate(proposed_constitution.as_slice()).as_ref(),
+    ));
+    let current_hash = atom_literal(&to_hex(
+        Checksum::generate(current_constitution.as_slice()).as_ref(),
+    ));
+
+    format!(
+        "ctx{{intent: 'gov:revise_constitution', 'gov:proposed_constitution_sha256': {proposed_hash}, \
+'gov:current_constitution_sha256': {current_hash}, 'gov:current_constitution_revision': {current_revision}, {}}}",
+        record_decision_context()
+    )
+}
+
 #[derive(Clone)]
 struct LogicAskExpectations(Rc<RefCell<VecDeque<(String, QueryServiceAskResponse)>>>);
 
@@ -273,13 +292,14 @@ fn assert_hash_matches(payload: &[u8], got: &Binary) {
 fn assert_decision_response(
     record: &DecisionResponse,
     expected_id: u64,
+    expected_constitution_revision: u64,
     expected_constitution: &Binary,
     expected_case: &str,
     expected_verdict: &str,
     expected_motivation: Option<&str>,
 ) {
     assert_eq!(record.decision_id, expected_id);
-    assert_eq!(record.constitution_revision, 0);
+    assert_eq!(record.constitution_revision, expected_constitution_revision);
     assert_hash_matches(expected_constitution.as_slice(), &record.constitution_hash);
 
     assert_eq!(record.case, expected_case);
@@ -919,7 +939,7 @@ fn query_decision_returns_recorded_decision_without_motivation() {
 
     let response = AxoneGovQueryMsgFns::decision(&env.app, 1).expect("Failed to query decision");
 
-    assert_decision_response(&response, 1, &constitution, &case_term, verdict, None);
+    assert_decision_response(&response, 1, 0, &constitution, &case_term, verdict, None);
 }
 
 #[test]
@@ -948,6 +968,7 @@ fn query_decision_returns_recorded_decision_with_motivation() {
     assert_decision_response(
         &response,
         1,
+        0,
         &constitution,
         &case_term,
         verdict,
@@ -1029,6 +1050,7 @@ decide(case{action:mint}, allowed)."
     assert_decision_response(
         &response.decisions[0],
         1,
+        0,
         &constitution,
         &record_decision_case("action: transfer"),
         "allowed",
@@ -1037,6 +1059,7 @@ decide(case{action:mint}, allowed)."
     assert_decision_response(
         &response.decisions[1],
         2,
+        0,
         &constitution,
         &record_decision_case("action: withdraw"),
         "denied",
@@ -1045,6 +1068,7 @@ decide(case{action:mint}, allowed)."
     assert_decision_response(
         &response.decisions[2],
         3,
+        0,
         &constitution,
         &record_decision_case("action: mint"),
         "allowed",
@@ -1096,6 +1120,18 @@ fn revise_constitution_succeeds_with_permitted_verdict() {
     assert_eq!(
         status.constitution_hash,
         Binary::from(expected_hash.as_slice())
+    );
+
+    let decision =
+        AxoneGovQueryMsgFns::decision(&env.app, 1).expect("Failed to query revision authorization");
+    assert_decision_response(
+        &decision,
+        1,
+        0,
+        &constitution,
+        &revise_constitution_case(&new_constitution, &constitution, 0),
+        "'gov:permitted'",
+        Some("'Revision allowed'"),
     );
 }
 
@@ -1244,8 +1280,8 @@ fn revise_constitution_fails_when_proposed_constitution_refuses_establish() {
             ask_decision_with_motivation("denied", "'No'"),
         )
         .install();
-    let env =
-        TestEnv::setup(constitution, hook, expectations).expect("Failed to setup test environment");
+    let env = TestEnv::setup(constitution.clone(), hook, expectations)
+        .expect("Failed to setup test environment");
 
     let err = env
         .app
@@ -1261,6 +1297,22 @@ fn revise_constitution_fails_when_proposed_constitution_refuses_establish() {
         msg.contains("gov:establish"),
         "expected gov:establish intent in error, got: {msg}"
     );
+
+    let status = env
+        .app
+        .constitution_status()
+        .expect("Failed to query constitution status");
+    assert_eq!(status.constitution_revision, 0);
+
+    let constitution_got = env
+        .app
+        .constitution()
+        .expect("Failed to query constitution");
+    assert_eq!(constitution_got.constitution, constitution);
+
+    let decisions = AxoneGovQueryMsgFns::decisions(&env.app, None, None)
+        .expect("Failed to query recorded decisions");
+    assert!(decisions.decisions.is_empty());
 }
 
 #[test]
@@ -1632,4 +1684,16 @@ fn revise_constitution_increments_revision_number() {
         .constitution_status()
         .expect("Failed to query constitution status");
     assert_eq!(status.constitution_revision, 2);
+
+    let decision =
+        AxoneGovQueryMsgFns::decision(&env.app, 2).expect("Failed to query second authorization");
+    assert_decision_response(
+        &decision,
+        2,
+        1,
+        &new_constitution_1,
+        &revise_constitution_case(&new_constitution_2, &new_constitution_1, 1),
+        "'gov:permitted'",
+        Some("'Second revision allowed'"),
+    );
 }

--- a/docs/axone-gov.md
+++ b/docs/axone-gov.md
@@ -61,14 +61,17 @@ A constitutional revision is performed by submitting an execution message that:
 
 1. Proposes a new constitution
 2. Evaluates the **current** constitution on a case containing the intent `gov:revise_constitution`
+3. Evaluates the **proposed** constitution on the constitutive intent `gov:establish`
 
-The revision is applied **only if** the verdict returned by the constitution is exactly:
+The revision is applied only when both decisions return:
 
 ```prolog
 gov:permitted
 ```
 
-Any other verdict (atom or compound term) results in a refusal.
+The authorization returned by the current constitution is recorded as a decision with that
+constitution's revision and hash. The decision record and revised constitution are committed in
+the same transaction, so a refused or failed revision records neither.
 
 ## InstantiateMsg
 
@@ -142,7 +145,7 @@ The complete case structure is (keys containing `:` are quoted atoms):
 
 `prolog ctx{ intent: &lt;intent_atom&gt;, % 'gov:revise_constitution' or 'gov:establish' 'gov:proposed_constitution_sha256': &lt;hex_atom&gt;, 'gov:current_constitution_sha256': &lt;hex_atom&gt;, 'gov:current_constitution_revision': &lt;integer&gt;, 'gov:module': module{ id: &lt;atom&gt;,       % Contract module ID (e.g., 'axone:axone-gov') version: &lt;atom&gt;   % Contract version (e.g., '1.2.3') }, 'cw:tx': tx{ message: msg{ sender: &lt;atom&gt;,                    % Bech32 address of message sender funds: [coin(Amount, Denom), ...]  % List of coins sent with message }, block: block{ height: &lt;integer&gt;,        % Block height time_seconds: &lt;integer&gt;,  % Block timestamp (seconds since epoch) tx_index: &lt;integer&gt;       % Transaction index } }, &lt;caller_provided_keys&gt;: &lt;caller_provided_values&gt;  % Any additional keys from caller's case } `
 
-The revision is applied only if both decisions return the verdict `gov:permitted`.
+The revision is applied only if both decisions return the verdict `gov:permitted`. The authorization decision returned by the current constitution is recorded with its current constitution revision and hash in the same transaction as the constitutional revision.
 
 | parameter                          | description                                                                                                                                                                                                                    |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -324,4 +327,4 @@ Response returned by `QueryMsg::Decision`.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-gov.json` (`c0d9d4e4566c0f12`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `axone-gov.json` (`173f3ae21b46c8c8`)_


### PR DESCRIPTION
In `axone-gov` contract, `reviseConstitution` now persists the current constitution's `gov:revise_constitution` authorisation as a decision record when a revision succeeds.

A constitutional revision derives its authority from the decision made by the currently active constitution. That authorisation is therefore a governance fact, not an internal control-flow check: it must remain auditable with the exact case, verdict, motivation, caller, block metadata, and constitution revision/hash that produced it.

Persisting it atomically with the revision preserves a strict invariant:

> A revised constitution exists iff its authorizing decision exists.

Without this, the chain can contain an amendment with no durable proof of the prior constitution’s authorisation. Conversely, recording before the full revision succeeds could create an orphan authorisation for a revision that never took effect. The single execution transaction prevents both states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Constitutional revisions now require authorization from both the current and proposed constitutions.
  * Approved revisions record the authorization decision, revision details, and constitution hashes.

* **Bug Fixes**
  * Failed or refused revisions no longer leave partial changes behind; decisions and constitutional updates are saved atomically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->